### PR TITLE
Updating flags for kiln

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # TBD
 
+### Changes
+* Upped the Lodestar wait-for-availability time to 60s
+* Updated flags for Kiln testnet compatibility
+* Switches key generation to use insecure mode, making key generation extremely fast
+
 # 0.4.3
 ### Features
 * Add extra debug logging to EL REST client, for debugging any issues

--- a/kurtosis-module/impl/participant_network/cl/lodestar/lodestar_launcher.go
+++ b/kurtosis-module/impl/participant_network/cl/lodestar/lodestar_launcher.go
@@ -35,7 +35,7 @@ const (
 	genesisSszRelFilepathInSharedDir       = "genesis.ssz"
 
 	maxNumHealthcheckRetries      = 30
-	timeBetweenHealthcheckRetries = 1 * time.Second
+	timeBetweenHealthcheckRetries = 2 * time.Second
 
 	beaconSuffixServiceId    = "beacon"
 	validatorSuffixServiceId = "validator"
@@ -200,7 +200,7 @@ func (launcher *LodestarClientLauncher) getBeaconContainerConfigSupplier(
 			"--network.subscribeAllSubnets=true",
 		}
 		if bootnodeContext != nil {
-			cmdArgs = append(cmdArgs, "--network.discv5.bootEnrs=" + bootnodeContext.GetENR())
+			cmdArgs = append(cmdArgs, "--network.discv5.bootEnrs="+bootnodeContext.GetENR())
 		}
 		if len(extraParams) > 0 {
 			cmdArgs = append(cmdArgs, extraParams...)

--- a/kurtosis-module/impl/participant_network/el/geth/geth_launcher.go
+++ b/kurtosis-module/impl/participant_network/el/geth/geth_launcher.go
@@ -40,18 +40,19 @@ const (
 
 	// The dirpath of the execution data directory on the client container
 	executionDataDirpathOnClientContainer = "/execution-data"
-	keystoreDirpathOnClientContainer = executionDataDirpathOnClientContainer + "/keystore"
+	keystoreDirpathOnClientContainer      = executionDataDirpathOnClientContainer + "/keystore"
 
 	gethKeysRelDirpathInSharedDir = "geth-keys"
 
-	expectedSecondsForGethInit = 5
-	expectedSecondsPerKeyImport = 8
+	expectedSecondsForGethInit                              = 5
+	expectedSecondsPerKeyImport                             = 8
 	expectedSecondsAfterNodeStartUntilHttpServerIsAvailable = 10
-	getNodeInfoTimeBetweenRetries = 1 * time.Second
+	getNodeInfoTimeBetweenRetries                           = 1 * time.Second
 
 	gethAccountPassword      = "password"          // Password that the Geth accounts will be locked with
 	gethAccountPasswordsFile = "/tmp/password.txt" // Importing an account to
 )
+
 var usedPorts = map[string]*services.PortSpec{
 	rpcPortId:          services.NewPortSpec(rpcPortNum, services.PortProtocol_TCP),
 	wsPortId:           services.NewPortSpec(wsPortNum, services.PortProtocol_TCP),
@@ -69,8 +70,8 @@ var verbosityLevels = map[module_io.GlobalClientLogLevel]string{
 
 type GethELClientLauncher struct {
 	genesisJsonFilepathOnModuleContainer string
-	prefundedAccountInfo []*genesis_consts.PrefundedAccount
-	networkId string
+	prefundedAccountInfo                 []*genesis_consts.PrefundedAccount
+	networkId                            string
 }
 
 func NewGethELClientLauncher(genesisJsonFilepathOnModuleContainer string, prefundedAccountInfo []*genesis_consts.PrefundedAccount, networkId string) *GethELClientLauncher {
@@ -109,7 +110,7 @@ func (launcher *GethELClientLauncher) Launch(
 		rpcPortNum,
 	)
 
-	maxNumRetries := expectedSecondsForGethInit + len(launcher.prefundedAccountInfo) * expectedSecondsPerKeyImport + expectedSecondsAfterNodeStartUntilHttpServerIsAvailable
+	maxNumRetries := expectedSecondsForGethInit + len(launcher.prefundedAccountInfo)*expectedSecondsPerKeyImport + expectedSecondsAfterNodeStartUntilHttpServerIsAvailable
 	nodeInfo, err := el.WaitForELClientAvailability(restClient, maxNumRetries, getNodeInfoTimeBetweenRetries)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "An error occurred waiting for the EL client to become available")
@@ -127,7 +128,6 @@ func (launcher *GethELClientLauncher) Launch(
 
 	return result, nil
 }
-
 
 // ====================================================================================================
 //                                       Private Helper Methods
@@ -192,9 +192,8 @@ func (launcher *GethELClientLauncher) getContainerConfigSupplier(
 			"--mine",
 			"--miner.etherbase=" + miningRewardsAccount,
 			fmt.Sprintf("--miner.threads=%v", numMiningThreads),
-			"--datadir="  + executionDataDirpathOnClientContainer,
+			"--datadir=" + executionDataDirpathOnClientContainer,
 			"--networkid=" + networkId,
-			"--catalyst",
 			"--http",
 			"--http.addr=0.0.0.0",
 			// WARNING: The admin info endpoint is enabled so that we can easily get ENR/enode, which means
@@ -211,7 +210,7 @@ func (launcher *GethELClientLauncher) getContainerConfigSupplier(
 		if bootnodeContext != nil {
 			launchNodeCmdArgs = append(
 				launchNodeCmdArgs,
-				"--bootnodes=" + bootnodeContext.GetEnode(),
+				"--bootnodes="+bootnodeContext.GetEnode(),
 			)
 		}
 		if len(extraParams) > 0 {

--- a/kurtosis-module/impl/participant_network/el/nethermind/nethermind_launcher.go
+++ b/kurtosis-module/impl/participant_network/el/nethermind/nethermind_launcher.go
@@ -121,11 +121,11 @@ func (launcher *NethermindELClientLauncher) getContainerConfigSupplier(
 				err,
 				"An error occurred copying the Nethermind genesis JSON file from '%v' into the Nethermind node being started",
 				launcher.genesisJsonFilepathOnModule,
-			 )
+			)
 		}
 
 		commandArgs := []string{
-			"--config=kintsugi",
+			"--config=kiln",
 			"--log=" + logLevel,
 			"--datadir=" + executionDataDirpathOnClientContainer,
 			"--Init.ChainSpecPath=" + nethermindGenesisJsonSharedPath.GetAbsPathOnServiceContainer(),
@@ -143,12 +143,12 @@ func (launcher *NethermindELClientLauncher) getContainerConfigSupplier(
 			fmt.Sprintf("--Network.P2PPort=%v", discoveryPortNum),
 			"--Merge.Enabled=true",
 			fmt.Sprintf("--Merge.TerminalTotalDifficulty=%v", launcher.totalTerminalDifficulty),
-			"--Merge.BlockAuthorAccount=" + miningRewardsAccount,
+			"--Merge.FeeRecipient=" + miningRewardsAccount,
 		}
 		if bootnodeCtx != nil {
 			commandArgs = append(
 				commandArgs,
-				"--Discovery.Bootnodes=" + bootnodeCtx.GetEnode(),
+				"--Discovery.Bootnodes="+bootnodeCtx.GetEnode(),
 			)
 		}
 		if len(extraParams) > 0 {

--- a/kurtosis-module/impl/prelaunch_data_generator/cl_validator_keystores/cl_validator_keystore_generator.go
+++ b/kurtosis-module/impl/prelaunch_data_generator/cl_validator_keystores/cl_validator_keystore_generator.go
@@ -29,7 +29,7 @@ func GenerateCLValidatorKeystores(
 ) (
 	*GenerateKeystoresResult,
 	error,
-){
+) {
 	sharedDir := serviceCtx.GetSharedDirectory()
 	outputSharedDir := sharedDir.GetChildPath(fmt.Sprintf(
 		"%v%v",
@@ -46,7 +46,7 @@ func GenerateCLValidatorKeystores(
 		nodeKeystoresDirname := fmt.Sprintf("node-%v-keystores", i)
 		nodeOutputSharedPath := outputSharedDir.GetChildPath(nodeKeystoresDirname)
 		subcommandStr := fmt.Sprintf(
-			"%v keystores --prysm-pass %v --out-loc %v --source-mnemonic \"%v\" --source-min %v --source-max %v",
+			"%v keystores --insecure --prysm-pass %v --out-loc %v --source-mnemonic \"%v\" --source-min %v --source-max %v",
 			keystoresGenerationToolName,
 			prysmPassword,
 			nodeOutputSharedPath.GetAbsPathOnServiceContainer(),


### PR DESCRIPTION
- I've increased the delay for `lodestar`, seems like `lodestar` requires more time to start their API
- Switches config on `nethermind`
- Removes `catalyst` flag on `geth`
- Switches key generation to `insecure` mode, this reduces the number of hash cycles. Crazy insecure, but we commit the mnemonic online, so it can't get worse :P

(Apologies, seems like my linter auto-indented things pre-commit)