### PR TITLE
improve dev ux and update teku CLI params

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ To configure the module behaviour, you can modify your `eth2-module-params.json`
 	// The address of the staking contract address on the Eth1 chain
 	"depositContractAddress": "0x4242424242424242424242424242424242424242",
 
+    // Number of seconds to be added to the calculated genesis time for EL
+    "ElGenesisTimeAdditionalDelay": 0
+
+    // Number of seconds to be added to the calculated genesis time for CL
+    "ClGenesisTimeAdditionalDelay": 0
+
 	// Number of seconds per slot on the Beacon chain
 	"secondsPerSlot": 12,
 
@@ -126,6 +132,9 @@ To configure the module behaviour, you can modify your `eth2-module-params.json`
 	// The number of validator keys that each CL validator node should get
 	"numValidatorKeysPerNode": 64,
 
+    // The number of extra validator keys should be generated, useful to join the network from outside kurtosis
+	"numExtraValidatorKeys": 64,
+
 	// This mnemonic will a) be used to create keystores for all the types of validators that we have and b) be used to generate a CL genesis.ssz that has the children
 	//  validator keys already preregistered as validators
 	"preregisteredValidatorKeysMnemonic": "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete"
@@ -139,6 +148,9 @@ To configure the module behaviour, you can modify your `eth2-module-params.json`
 
     // If set, the module will block until a finalized epoch has occurred
     "waitForFinalization": false,
+
+    // If set, the module will block until a CL genesis has occurred
+    "waitForClGenesis": true,
 
     // The global log level that all clients should log at
     // Valid values are "error", "warn", "info", "debug", and "trace"

--- a/kurtosis-module/impl/module.go
+++ b/kurtosis-module/impl/module.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
 	"time"
+	"strings"
 )
 
 const (
@@ -122,18 +123,22 @@ func (e Eth2KurtosisModule) Execute(enclaveCtx *enclaves.EnclaveContext, seriali
 	logrus.Info("Successfully launched transaction spammer")
 
 
-	logrus.Info("Waiting until CL genesis occurs to add forkmon...")
-	// We need to wait until the CL genesis has been reached to launch Forkmon because it has a bug (as of 2022-01-18) where
-	//  if a CL ndoe's getHealth endpoint returns a non-200 error code, Forkmon will mark the node as failed and will never revisit it
-	// This is fine with nodes who report 200 before genesis, but certain nodes (e.g. Lighthouse) will report a 503 before genesis
-	// Therefore, the simple fix is wait until CL genesis to start Forkmon
-	secondsRemainingUntilClGenesis := clGenesisUnixTimestamp - uint64(time.Now().Unix())
-	if secondsRemainingUntilClGenesis < 0 {
-		secondsRemainingUntilClGenesis = 0
+	if paramsObj.WaitForClGenesis {
+		logrus.Info("Waiting until CL genesis occurs to add forkmon...")
+		// We need to wait until the CL genesis has been reached to launch Forkmon because it has a bug (as of 2022-01-18) where
+		//  if a CL ndoe's getHealth endpoint returns a non-200 error code, Forkmon will mark the node as failed and will never revisit it
+		// This is fine with nodes who report 200 before genesis, but certain nodes (e.g. Lighthouse) will report a 503 before genesis
+		// Therefore, the simple fix is wait until CL genesis to start Forkmon
+		secondsRemainingUntilClGenesis := clGenesisUnixTimestamp - uint64(time.Now().Unix())
+		if secondsRemainingUntilClGenesis < 0 {
+			secondsRemainingUntilClGenesis = 0
+		}
+		durationUntilClGenesis := time.Duration(int64(secondsRemainingUntilClGenesis)) * time.Second
+		time.Sleep(durationUntilClGenesis)
+		logrus.Info("CL genesis has occurred")
+	} else {
+		logrus.Info("The wait-for-mining flag was set to false. Forkmon will be started immediately but may not work properly.")
 	}
-	durationUntilClGenesis := time.Duration(int64(secondsRemainingUntilClGenesis)) * time.Second
-	time.Sleep(durationUntilClGenesis)
-	logrus.Info("CL genesis has occurred")
 
 
 	logrus.Info("Launching forkmon...")
@@ -189,6 +194,19 @@ func (e Eth2KurtosisModule) Execute(enclaveCtx *enclaves.EnclaveContext, seriali
 		logrus.Info("First finalized epoch occurred successfully")
 	}
 
+	allClClientPeers := []string{}
+	for _, clClientCtx := range allClClientContexts {
+		allClClientPeers = append(allClClientPeers, fmt.Sprintf("/ip4/%s/tcp/%v/p2p/%s", clClientCtx.GetPublicIPAddress(), clClientCtx.GetPublicHTTPPortNum(), clClientCtx.GetPeerId()))
+	}
+
+	allElClientPeers := []string{}
+	for _, elClientCtx := range allElClientContexts {
+		internal := fmt.Sprintf("@%s:%v",elClientCtx.GetIPAddress(),elClientCtx.GetDiscoveryPortNum())
+		external := fmt.Sprintf("@%s:%v",elClientCtx.GetPublicIPAddress(),elClientCtx.GetPublicDiscoveryPortNum())
+
+		allElClientPeers = append(allElClientPeers, strings.Replace(elClientCtx.GetEnode(),internal,external,1))
+	}
+
 	responseObj := &module_io.ExecuteResponse{
 		ForkmonPublicURL: forkmonPublicUrl,
 		PrometheusPublicURL: prometheusPublicUrl,
@@ -198,6 +216,8 @@ func (e Eth2KurtosisModule) Execute(enclaveCtx *enclaves.EnclaveContext, seriali
 			User: grafanaUser,
 			Password: grafanaPassword,
 		},
+		ClPeers: allClClientPeers,
+		ElPeers: allElClientPeers,
 	}
 	responseStr, err := json.MarshalIndent(responseObj, responseJsonLinePrefixStr, responseJsonLineIndentStr)
 	if err != nil {

--- a/kurtosis-module/impl/module_io/default_params.go
+++ b/kurtosis-module/impl/module_io/default_params.go
@@ -58,16 +58,20 @@ func GetDefaultExecuteParams() *ExecuteParams {
 		Network: &NetworkParams{
 			NetworkID:                          "3151908",
 			DepositContractAddress:             "0x4242424242424242424242424242424242424242",
+			ClGenesisTimeAdditionalDelay:       0,
+			ElGenesisTimeAdditionalDelay:       0,
 			SecondsPerSlot:                     12,
 			SlotsPerEpoch:                      32,
 			AltairForkEpoch:                    1,
 			MergeForkEpoch:                     2,
 			TotalTerminalDifficulty:            100000000,
 			NumValidatorKeysPerNode:            64,
+			NumExtraValidatorKeys: 			    0,
 			PreregisteredValidatorKeysMnemonic: "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete",
 		},
 		WaitForMining:       true,
 		WaitForFinalization: false,
+		WaitForClGenesis:    true,
 		ClientLogLevel:      GlobalClientLogLevel_Info,
 	}
 	// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/kurtosis-module/impl/module_io/params.go
+++ b/kurtosis-module/impl/module_io/params.go
@@ -89,6 +89,9 @@ type ExecuteParams struct {
 	// If set, the module will block until a finalized epoch has occurred
 	WaitForFinalization bool	`json:"waitForFinalization"`
 
+	// If set, the module will block until a CL genesis has occurred
+	WaitForClGenesis bool	`json:"waitForClGenesis"`
+
 	// The log level that the started clients should log at
 	ClientLogLevel GlobalClientLogLevel `json:"logLevel"`
 }
@@ -142,6 +145,12 @@ type NetworkParams struct {
 	// The address of the staking contract address on the Eth1 chain
 	DepositContractAddress string	`json:"depositContractAddress"`
 
+	// Number of seconds to be added to the calculated genesis time for CL
+	ClGenesisTimeAdditionalDelay uint32	`json:"clGenesisTimeAdditionalDelay"`
+
+	// Number of seconds to be added to the calculated genesis time for EL
+	ElGenesisTimeAdditionalDelay uint32	`json:"elGenesisTimeAdditionalDelay"`
+
 	// Number of seconds per slot on the Beacon chain
 	SecondsPerSlot uint32	`json:"secondsPerSlot"`
 
@@ -164,6 +173,9 @@ type NetworkParams struct {
 
 	// The number of validator keys that each CL validator node should get
 	NumValidatorKeysPerNode uint32	`json:"numValidatorKeysPerNode"`
+
+	// The number of additional validator keys we want to generate for external validators
+	NumExtraValidatorKeys uint32	`json:"numExtraValidatorKeys"`
 
 	// This menmonic will a) be used to create keystores for all the types of validators that we have and b) be used to generate a CL genesis.ssz that has the children
 	//  validator keys already preregistered as validators

--- a/kurtosis-module/impl/module_io/response.go
+++ b/kurtosis-module/impl/module_io/response.go
@@ -5,6 +5,8 @@ type ExecuteResponse struct {
 	ForkmonPublicURL string	`json:"forkmonUrl"`
 	PrometheusPublicURL string `json:"prometheusUrl"`
 	GrafanaInfo *GrafanaInfo `json:"grafana"`
+	ClPeers []string `json:"clPeers"`
+	ElPeers []string `json:"elPeers"`
 }
 
 type GrafanaInfo struct {

--- a/kurtosis-module/impl/participant_network/cl/cl_client_context.go
+++ b/kurtosis-module/impl/participant_network/cl/cl_client_context.go
@@ -3,19 +3,43 @@ package cl
 import "github.com/kurtosis-tech/eth2-merge-kurtosis-module/kurtosis-module/impl/participant_network/cl/cl_client_rest_client"
 
 type CLClientContext struct {
-	enr         string
-	ipAddr      string
-	httpPortNum uint16
+	enr               string
+	peerId            string
+	ipAddr            string
+	httpPortNum       uint16
+	publicIpAddr      string
+	publicHttpPortNum uint16
 	nodesMetricsInfo []*CLNodeMetricsInfo
 	restClient *cl_client_rest_client.CLClientRESTClient
 }
 
-func NewCLClientContext(enr string, ipAddr string, httpPortNum uint16, nodesMetricsInfo []*CLNodeMetricsInfo, restClient *cl_client_rest_client.CLClientRESTClient) *CLClientContext {
-	return &CLClientContext{enr: enr, ipAddr: ipAddr, httpPortNum: httpPortNum, nodesMetricsInfo: nodesMetricsInfo, restClient: restClient}
+func NewCLClientContext(
+	enr string,
+	peerId string,
+	ipAddr string,
+	httpPortNum uint16,
+	publicIpAddr string,
+	publicHttpPortNum uint16,
+	nodesMetricsInfo []*CLNodeMetricsInfo, 
+	restClient *cl_client_rest_client.CLClientRESTClient) *CLClientContext {
+	return &CLClientContext{
+		enr: enr,
+		peerId: peerId,
+		ipAddr: ipAddr,
+		httpPortNum: httpPortNum,
+		publicIpAddr: publicIpAddr,
+		publicHttpPortNum: publicHttpPortNum,
+		nodesMetricsInfo: nodesMetricsInfo,
+		restClient: restClient,
+	}
 }
 
 func (ctx *CLClientContext) GetENR() string {
 	return ctx.enr
+}
+
+func (ctx *CLClientContext) GetPeerId() string {
+	return ctx.peerId
 }
 
 func (ctx *CLClientContext) GetIPAddress() string {
@@ -32,4 +56,12 @@ func (ctx *CLClientContext) GetRESTClient() *cl_client_rest_client.CLClientRESTC
 
 func (ctx *CLClientContext) GetNodesMetricsInfo() []*CLNodeMetricsInfo {
 	return ctx.nodesMetricsInfo
+}
+
+func (ctx *CLClientContext) GetPublicIPAddress() string {
+	return ctx.publicIpAddr
+}
+
+func (ctx *CLClientContext) GetPublicHTTPPortNum() uint16 {
+	return ctx.publicHttpPortNum
 }

--- a/kurtosis-module/impl/participant_network/cl/cl_client_rest_client/api_response_objects.go
+++ b/kurtosis-module/impl/participant_network/cl/cl_client_rest_client/api_response_objects.go
@@ -6,6 +6,7 @@ type GetNodeIdentityResponse struct {
 
 type NodeIdentity struct {
 	ENR string `json:"enr"`
+	PeerId string `json:"peer_id"`
 }
 
 type GetBlockHeadersResponse struct {

--- a/kurtosis-module/impl/participant_network/cl/lighthouse/lighthouse_launcher.go
+++ b/kurtosis-module/impl/participant_network/cl/lighthouse/lighthouse_launcher.go
@@ -162,10 +162,18 @@ func (launcher *LighthouseCLClientLauncher) Launch(
 	validatorNodeMetricsInfo := cl.NewCLNodeMetricsInfo(string(validatorNodeServiceId), metricsPath, validatorMetricsUrl)
 	nodesMetricsInfo := []*cl.CLNodeMetricsInfo{beaconNodeMetricsInfo, validatorNodeMetricsInfo}
 
+	httpPublicPort, found := beaconServiceCtx.GetPublicPorts()[beaconHttpPortID]
+	if !found {
+		return nil, stacktrace.NewError("Expected new Lighthouse Beacon service to have public port with ID '%v', but none was found", beaconHttpPortID)
+	}
+
 	result := cl.NewCLClientContext(
 		nodeIdentity.ENR,
+		nodeIdentity.PeerId,
 		beaconServiceCtx.GetPrivateIPAddress(),
 		beaconHttpPortNum,
+		beaconServiceCtx.GetMaybePublicIPAddress(),
+		httpPublicPort.GetNumber(),
 		nodesMetricsInfo,
 		beaconRestClient,
 	)

--- a/kurtosis-module/impl/participant_network/cl/lodestar/lodestar_launcher.go
+++ b/kurtosis-module/impl/participant_network/cl/lodestar/lodestar_launcher.go
@@ -137,10 +137,18 @@ func (launcher *LodestarClientLauncher) Launch(
 	nodeMetricsInfo := cl.NewCLNodeMetricsInfo(string(serviceId), metricsPath, metricsUrl)
 	nodesMetricsInfo := []*cl.CLNodeMetricsInfo{nodeMetricsInfo}
 
+	httpPublicPort, found := beaconServiceCtx.GetPublicPorts()[httpPortID]
+	if !found {
+		return nil, stacktrace.NewError("Expected new Lodestar service to have public port with ID '%v', but none was found", httpPortID)
+	}
+
 	result := cl.NewCLClientContext(
 		nodeIdentity.ENR,
+		nodeIdentity.PeerId,
 		beaconServiceCtx.GetPrivateIPAddress(),
 		httpPortNum,
+		beaconServiceCtx.GetMaybePublicIPAddress(),
+		httpPublicPort.GetNumber(),
 		nodesMetricsInfo,
 		beaconRestClient,
 	)

--- a/kurtosis-module/impl/participant_network/cl/nimbus/nimbus_launcher.go
+++ b/kurtosis-module/impl/participant_network/cl/nimbus/nimbus_launcher.go
@@ -143,10 +143,18 @@ func (launcher NimbusLauncher) Launch(
 	nodeMetricsInfo := cl.NewCLNodeMetricsInfo(string(serviceId), metricsPath, metricsUrl)
 	nodesMetricsInfo := []*cl.CLNodeMetricsInfo{nodeMetricsInfo}
 
+	httpPublicPort, found := serviceCtx.GetPublicPorts()[httpPortID]
+	if !found {
+		return nil, stacktrace.NewError("Expected new Nimbus service to have public port with ID '%v', but none was found", httpPortID)
+	}
+
 	result := cl.NewCLClientContext(
 		nodeIdentity.ENR,
+		nodeIdentity.PeerId,
 		serviceCtx.GetPrivateIPAddress(),
 		httpPortNum,
+		serviceCtx.GetMaybePublicIPAddress(),
+		httpPublicPort.GetNumber(),
 		nodesMetricsInfo,
 		restClient,
 	)

--- a/kurtosis-module/impl/participant_network/cl/prysm/prysm_launcher.go
+++ b/kurtosis-module/impl/participant_network/cl/prysm/prysm_launcher.go
@@ -190,10 +190,18 @@ func (launcher *PrysmCLClientLauncher) Launch(
 	validatorNodeMetricsInfo := cl.NewCLNodeMetricsInfo(string(validatorNodeServiceId), metricsPath, validatorMetricsUrl)
 	nodesMetricsInfo := []*cl.CLNodeMetricsInfo{beaconNodeMetricsInfo, validatorNodeMetricsInfo}
 
+	httpPublicPort, found := beaconServiceCtx.GetPublicPorts()[httpPortID]
+	if !found {
+		return nil, stacktrace.NewError("Expected new Prysm Beacon to have public port with ID '%v', but none was found", httpPortID)
+	}
+
 	result := cl.NewCLClientContext(
 		nodeIdentity.ENR,
+		nodeIdentity.PeerId,
 		beaconServiceCtx.GetPrivateIPAddress(),
 		httpPortNum,
+		beaconServiceCtx.GetMaybePublicIPAddress(),
+		httpPublicPort.GetNumber(),
 		nodesMetricsInfo,
 		beaconRestClient,
 	)

--- a/kurtosis-module/impl/participant_network/el/besu/besu_launcher.go
+++ b/kurtosis-module/impl/participant_network/el/besu/besu_launcher.go
@@ -99,6 +99,11 @@ func (launcher *BesuELClientLauncher) Launch(
 		return nil, stacktrace.Propagate(err, "An error occurred waiting for the EL client to become available")
 	}
 
+	publicDiscoveryPortNum, found := serviceCtx.GetPublicPorts()[tcpDiscoveryPortId]
+	if !found {
+		return nil, stacktrace.NewError("Expected new Besu EL client service to have public discovery port with ID '%v', but none was found", tcpDiscoveryPortId)
+	}
+
 	miningWaiter := mining_waiter.NewMiningWaiter(restClient)
 	result := el.NewELClientContext(
 		// TODO Figure out how to get the ENR so CL clients can connect to it!!
@@ -106,6 +111,9 @@ func (launcher *BesuELClientLauncher) Launch(
 		nodeInfo.Enode,
 		serviceCtx.GetPrivateIPAddress(),
 		rpcPortNum,
+		discoveryPortNum,
+		serviceCtx.GetMaybePublicIPAddress(),
+		publicDiscoveryPortNum.GetNumber(),
 		wsPortNum,
 		miningWaiter,
 	)

--- a/kurtosis-module/impl/participant_network/el/el_client_context.go
+++ b/kurtosis-module/impl/participant_network/el/el_client_context.go
@@ -5,12 +5,15 @@ type ELClientContext struct {
 	enode string
 	ipAddr string
 	rpcPortNum  uint16
+	discoveryPortNum uint16
+	publicIpAddr string
+	publicDiscoveryPortNum uint16
 	wsPortNum uint16
 	miningWaiter ELClientMiningWaiter
 }
 
-func NewELClientContext(enr string, enode string, ipAddr string, rpcPortNum uint16, wsPortNum uint16, miningWaiter ELClientMiningWaiter) *ELClientContext {
-	return &ELClientContext{enr: enr, enode: enode, ipAddr: ipAddr, rpcPortNum: rpcPortNum, wsPortNum: wsPortNum, miningWaiter: miningWaiter}
+func NewELClientContext(enr string, enode string, ipAddr string, rpcPortNum uint16,discoveryPortNum uint16, publicIpAddr string, publicDiscoveryPortNum uint16, wsPortNum uint16, miningWaiter ELClientMiningWaiter) *ELClientContext {
+	return &ELClientContext{enr: enr, enode: enode, ipAddr: ipAddr, rpcPortNum: rpcPortNum, discoveryPortNum: discoveryPortNum, publicIpAddr: publicIpAddr, publicDiscoveryPortNum: publicDiscoveryPortNum, wsPortNum: wsPortNum, miningWaiter: miningWaiter}
 }
 
 func (ctx *ELClientContext) GetENR() string {
@@ -25,10 +28,18 @@ func (ctx *ELClientContext) GetIPAddress() string {
 func (ctx *ELClientContext) GetRPCPortNum() uint16 {
 	return ctx.rpcPortNum
 }
+func (ctx *ELClientContext) GetDiscoveryPortNum() uint16 {
+	return ctx.discoveryPortNum
+}
 func (ctx *ELClientContext) GetWSPortNum() uint16 {
 	return ctx.wsPortNum
 }
 func (ctx *ELClientContext) GetMiningWaiter() ELClientMiningWaiter {
 	return ctx.miningWaiter
 }
-
+func (ctx *ELClientContext) GetPublicIPAddress() string {
+	return ctx.publicIpAddr
+}
+func (ctx *ELClientContext) GetPublicDiscoveryPortNum() uint16 {
+	return ctx.publicDiscoveryPortNum
+}

--- a/kurtosis-module/impl/participant_network/el/geth/geth_launcher.go
+++ b/kurtosis-module/impl/participant_network/el/geth/geth_launcher.go
@@ -116,12 +116,20 @@ func (launcher *GethELClientLauncher) Launch(
 		return nil, stacktrace.Propagate(err, "An error occurred waiting for the EL client to become available")
 	}
 
+	publicDiscoveryPortNum, found := serviceCtx.GetPublicPorts()[tcpDiscoveryPortId]
+	if !found {
+		return nil, stacktrace.NewError("Expected new Geth EL client service to have public discovery port with ID '%v', but none was found", tcpDiscoveryPortId)
+	}
+
 	miningWaiter := mining_waiter.NewMiningWaiter(restClient)
 	result := el.NewELClientContext(
 		nodeInfo.ENR,
 		nodeInfo.Enode,
 		serviceCtx.GetPrivateIPAddress(),
 		rpcPortNum,
+		discoveryPortNum,
+		serviceCtx.GetMaybePublicIPAddress(),
+		publicDiscoveryPortNum.GetNumber(),
 		wsPortNum,
 		miningWaiter,
 	)

--- a/kurtosis-module/impl/participant_network/participant_network.go
+++ b/kurtosis-module/impl/participant_network/participant_network.go
@@ -82,6 +82,7 @@ func LaunchParticipantNetwork(
 	clValidatorData, err := prelaunchDataGeneratorCtx.GenerateCLValidatorData(
 		numParticipants,
 		networkParams.NumValidatorKeysPerNode,
+		networkParams.NumExtraValidatorKeys,
 	)
 	if err != nil {
 		return nil, 0, stacktrace.Propagate(err, "An error occurred generating CL validator keys")
@@ -91,7 +92,7 @@ func LaunchParticipantNetwork(
 	// Per Pari's recommendation, we want to start all EL clients before any CL clients and wait until they're all mining blocks before
 	//  we start the CL clients. This matches the real world, where Eth1 definitely exists before Eth2
 	logrus.Info("Generating EL client genesis data...")
-	elGenesisTimestamp := uint64(time.Now().Unix())
+	elGenesisTimestamp := uint64(time.Now().Unix()) + uint64(networkParams.ElGenesisTimeAdditionalDelay)
 	elGenesisData, err := prelaunchDataGeneratorCtx.GenerateELGenesisData(
 		elGenesisGenerationConfigTemplate,
 		elGenesisTimestamp,
@@ -191,7 +192,8 @@ func LaunchParticipantNetwork(
 	// Set the genesis timestamp in the future so we don't start running slots until all the CL nodes are up
 	clGenesisTimestamp := uint64(time.Now().Unix()) +
 		uint64(clGenesisDataGenerationTime.Seconds()) +
-		uint64(numParticipants)*uint64(clNodeStartupTime.Seconds())
+		uint64(numParticipants)*uint64(clNodeStartupTime.Seconds()) +
+		uint64(networkParams.ClGenesisTimeAdditionalDelay)
 	clGenesisData, err := prelaunchDataGeneratorCtx.GenerateCLGenesisData(
 		clGenesisConfigTemplate,
 		clGenesisMnemonicsYmlTemplate,
@@ -201,6 +203,7 @@ func LaunchParticipantNetwork(
 		networkParams.MergeForkEpoch,
 		numParticipants,
 		networkParams.NumValidatorKeysPerNode,
+		networkParams.NumExtraValidatorKeys,
 	)
 	if err != nil {
 		return nil, 0, stacktrace.Propagate(err, "An error occurred generating the CL client genesis data")

--- a/kurtosis-module/impl/prelaunch_data_generator/cl_validator_keystores/cl_validator_keystore_generator.go
+++ b/kurtosis-module/impl/prelaunch_data_generator/cl_validator_keystores/cl_validator_keystore_generator.go
@@ -9,7 +9,8 @@ import (
 )
 
 const (
-	outputDirnamePrefix = "cl-validator-keystores-"
+	outputDirnamePrefix     = "cl-validator-keystores-"
+	outputDirExternalPrefix = "external-validator-keystores-"
 
 	// Prysm keystores are encrypted with a password
 	prysmPassword = "password"
@@ -26,6 +27,7 @@ func GenerateCLValidatorKeystores(
 	mnemonic string,
 	numNodes uint32,
 	numValidatorsPerNode uint32,
+	numExtraValidatorKeys uint32,
 ) (
 	*GenerateKeystoresResult,
 	error,
@@ -34,6 +36,12 @@ func GenerateCLValidatorKeystores(
 	outputSharedDir := sharedDir.GetChildPath(fmt.Sprintf(
 		"%v%v",
 		outputDirnamePrefix,
+		time.Now().Unix(),
+	))
+
+	outputExternalSharedDir := sharedDir.GetChildPath(fmt.Sprintf(
+		"%v%v",
+		outputDirExternalPrefix,
 		time.Now().Unix(),
 	))
 
@@ -62,6 +70,18 @@ func GenerateCLValidatorKeystores(
 		startIndex = stopIndex
 		stopIndex = stopIndex + numValidatorsPerNode
 	}
+
+	// generate extra validator append to allSubcommandStrs
+	subcommandStr := fmt.Sprintf(
+		"%v keystores --insecure --prysm-pass %v --out-loc %v --source-mnemonic \"%v\" --source-min %v --source-max %v",
+		keystoresGenerationToolName,
+		prysmPassword,
+		outputExternalSharedDir.GetAbsPathOnServiceContainer(),
+		mnemonic,
+		stopIndex,
+		stopIndex+numExtraValidatorKeys,
+	)
+	allSubcommandStrs = append(allSubcommandStrs, subcommandStr)
 
 	commandStr := strings.Join(allSubcommandStrs, " && ")
 

--- a/kurtosis-module/impl/prelaunch_data_generator/cl_validator_keystores/cl_validator_keystore_generator.go
+++ b/kurtosis-module/impl/prelaunch_data_generator/cl_validator_keystores/cl_validator_keystore_generator.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	outputDirnamePrefix     = "cl-validator-keystores-"
-	outputDirExternalPrefix = "external-validator-keystores-"
+	outputDirExtraPrefix    = "extra-validator-keystores-"
 
 	// Prysm keystores are encrypted with a password
 	prysmPassword = "password"
@@ -39,9 +39,9 @@ func GenerateCLValidatorKeystores(
 		time.Now().Unix(),
 	))
 
-	outputExternalSharedDir := sharedDir.GetChildPath(fmt.Sprintf(
+	outputExtraSharedDir := sharedDir.GetChildPath(fmt.Sprintf(
 		"%v%v",
-		outputDirExternalPrefix,
+		outputDirExtraPrefix,
 		time.Now().Unix(),
 	))
 
@@ -76,7 +76,7 @@ func GenerateCLValidatorKeystores(
 		"%v keystores --insecure --prysm-pass %v --out-loc %v --source-mnemonic \"%v\" --source-min %v --source-max %v",
 		keystoresGenerationToolName,
 		prysmPassword,
-		outputExternalSharedDir.GetAbsPathOnServiceContainer(),
+		outputExtraSharedDir.GetAbsPathOnServiceContainer(),
 		mnemonic,
 		stopIndex,
 		stopIndex+numExtraValidatorKeys,

--- a/kurtosis-module/impl/prelaunch_data_generator/prelaunch_data_generator_context.go
+++ b/kurtosis-module/impl/prelaunch_data_generator/prelaunch_data_generator_context.go
@@ -42,12 +42,14 @@ func (ctx *PrelaunchDataGeneratorContext) GenerateELGenesisData(
 func (ctx *PrelaunchDataGeneratorContext) GenerateCLValidatorData(
 	numValidatorNodes uint32,
 	numValidatorsPerNode uint32,
+	numExtraValidatorKeys uint32,
 ) (*cl_validator_keystores.GenerateKeystoresResult, error) {
 	result, err := cl_validator_keystores.GenerateCLValidatorKeystores(
 		ctx.serviceCtx,
 		ctx.preregisteredValidatorKeysMnemonic,
 		numValidatorNodes,
 		numValidatorsPerNode,
+		numExtraValidatorKeys,
 	)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "An error occurred generating the CL client validator keystores")
@@ -64,11 +66,12 @@ func (ctx *PrelaunchDataGeneratorContext) GenerateCLGenesisData(
 	mergeForkEpoch uint64,
 	numValidatorNodes uint32,
 	numValidatorsPerNode uint32,
+	numExtraValidatorKeys uint32,
 ) (
 	*cl_genesis.CLGenesisData,
 	error,
 ) {
-	numValidatorKeysToPreregister := numValidatorNodes * numValidatorsPerNode
+	numValidatorKeysToPreregister := (numValidatorNodes * numValidatorsPerNode) + numExtraValidatorKeys
 	result, err := cl_genesis.GenerateCLGenesisData(
 		genesisGenerationConfigYmlTemplate,
 		genesisGenerationMnemonicsYmlTemplate,

--- a/kurtosis-module/impl/prelaunch_data_generator/prelaunch_data_generator_launcher_test.go
+++ b/kurtosis-module/impl/prelaunch_data_generator/prelaunch_data_generator_launcher_test.go
@@ -106,6 +106,7 @@ func TestPrelaunchGenesisGeneration(t *testing.T) {
 		networkParams.MergeForkEpoch,
 		uint32(len(participantParams)),
 		networkParams.NumValidatorKeysPerNode,
+		networkParams.NumExtraValidatorKeys,
 	)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
### New params

- `waitForClGenesis` to skip forkmon wait 
- `network`:
   - `numExtraValidatorKeys` to produce additional keys that will be provided in `extra-validator-keystores-<timestamp>` 
   - `ElGenesisTimeAdditionalDelay`
   - `ClGenesisTimeAdditionalDelay`

###  Module output enriched with info to be able to connect to from an external node:
```json
{
...
"clPeers": [
    "/ip4/127.0.0.1/tcp/62743/p2p/16Uiu2HAmDBi3f8ujGH4xr7WNhsw76kZCXYSoyKz2uBAjxwRX4747"
  ],
"elPeers": [
"enode://02801d9407356fd5791f87f1d02c399c12897395807e697044c5e456efe1ac84683f11caa7a721434e5eb4586833b29533ef1c8dfeaff8d8e69aca5eedfd17ae@127.0.0.1:61828"
]
}
```

### fix teku params
- `--Xee-endpoint=` -> `--ee-endpoint=`
- `--Xvalidators-proposer-default-fee-recipient=` -> `--validators-proposer-default-fee-recipient=`

fixes kurtosis-tech/eth2-package#61