### PR TITLE
Allow nethermind to be backup bootnode

### DIFF
--- a/kurtosis-module/impl/module_io/params_deserializer.go
+++ b/kurtosis-module/impl/module_io/params_deserializer.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	expectedSecondsPerSlot = 12
-	expectedSlotsPerEpoch = 32
+	expectedSlotsPerEpoch  = 32
 
 	// TODO Remove this once Teku fixes its bug with merge fork epoch:
 	//  https://discord.com/channels/697535391594446898/697539289042649190/935029250858299412
@@ -46,7 +46,7 @@ func DeserializeAndValidateParams(paramsStr string) (*ExecuteParams, error) {
 				idx,
 				elClientType,
 				strings.Join(validClientTypes, ", "),
-			 )
+			)
 		}
 		if participant.ELClientImage == useDefaultElImageKeyword {
 			defaultElClientImage, found := defaultElImages[elClientType]
@@ -61,7 +61,6 @@ func DeserializeAndValidateParams(paramsStr string) (*ExecuteParams, error) {
 			paramsObj.Participants[idx].ELExtraParams = []string{}
 		}
 
-
 		clClientType := participant.CLClientType
 		if _, found := validParticipantCLClientTypes[clClientType]; !found {
 			validClientTypes := []string{}
@@ -73,7 +72,7 @@ func DeserializeAndValidateParams(paramsStr string) (*ExecuteParams, error) {
 				idx,
 				clClientType,
 				strings.Join(validClientTypes, ", "),
-			 )
+			)
 		}
 		if participant.CLClientImage == useDefaultClImageKeyword {
 			defaultClClientImage, found := defaultClImages[clClientType]
@@ -138,7 +137,7 @@ func DeserializeAndValidateParams(paramsStr string) (*ExecuteParams, error) {
 			"We need %v validators (enough for two epochs, with one validator per slot), but only have %v",
 			requiredNumValidators,
 			actualNumValidators,
-		 )
+		)
 	}
 	if len(strings.TrimSpace(networkParams.PreregisteredValidatorKeysMnemonic)) == 0 {
 		return nil, stacktrace.NewError("Preregistered validator keys mnemonic must not be empty")
@@ -160,8 +159,7 @@ func DeserializeAndValidateParams(paramsStr string) (*ExecuteParams, error) {
 
 	// TODO Remove this once Nethermind no longer breaks if there's only one bootnode
 	participantParams := paramsObj.Participants
-	hasNethermindAsBootnodeOrSecondNode := (len(participantParams) >= 1 && participantParams[0].ELClientType == ParticipantELClientType_Nethermind) ||
-		(len(participantParams) >= 2 && participantParams[1].ELClientType == ParticipantELClientType_Nethermind)
+	hasNethermindAsBootnodeOrSecondNode := len(participantParams) >= 1 && participantParams[0].ELClientType == ParticipantELClientType_Nethermind
 	if hasNethermindAsBootnodeOrSecondNode {
 		return nil, stacktrace.NewError(
 			"Due to a bug in Nethermind peering, Nethermind cannot be either the first or second EL node (see https://discord.com/channels/783719264308953108/933134266580234290/958049716065665094)",

--- a/kurtosis-module/impl/module_io/params_deserializer.go
+++ b/kurtosis-module/impl/module_io/params_deserializer.go
@@ -157,14 +157,5 @@ func DeserializeAndValidateParams(paramsStr string) (*ExecuteParams, error) {
 		)
 	}
 
-	// TODO Remove this once Nethermind no longer breaks if there's only one bootnode
-	participantParams := paramsObj.Participants
-	hasNethermindAsBootnodeOrSecondNode := len(participantParams) >= 1 && participantParams[0].ELClientType == ParticipantELClientType_Nethermind
-	if hasNethermindAsBootnodeOrSecondNode {
-		return nil, stacktrace.NewError(
-			"Due to a bug in Nethermind peering, Nethermind cannot be either the first or second EL node (see https://discord.com/channels/783719264308953108/933134266580234290/958049716065665094)",
-		)
-	}
-
 	return paramsObj, nil
 }


### PR DESCRIPTION
Fixes the check where nethermind is not allowed to be the second bootnode. We need to remove this check since nethermind needs to be used as the second bootnode to fix the peering issue. 

