### PR TITLE
Add Erigon EL Client Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You can find the latest Kiln compatible docker images here: https://notes.ethere
 
             // The Docker image that should be used for the EL client; leave blank to use the default for the client type
             // Defaults by client (note that Prysm is different in that it requires two images - a Beacon and a validator - separated by a comma):
-            // - lighthouse: sigp/lighthouse:latest-unstable
+            // - lighthouse: sigp/lighthouse:latest
             // - teku: consensys/teku:latest
             // - nimbus: parithoshj/nimbus:merge-97cefaa
             // - prysm: gcr.io/prysmaticlabs/prysm/beacon-chain:latest,gcr.io/prysmaticlabs/prysm/validator:latest

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can find the latest Kiln compatible docker images here: https://notes.ethere
             // The Docker image that should be used for the EL client; leave blank to use the default for the client type
             // Defaults by client:
             // - geth: parithoshj/geth:master
-            // - erigon: thorax/erigon:alpha
+            // - erigon: thorax/erigon:devel
             // - nethermind: nethermindeth/nethermind:kiln_0.11
             // - besu: hyperledger/besu:22.4.0-RC2-SNAPSHOT
             "elImage": "",

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ You can find the latest Kiln compatible docker images here: https://notes.ethere
 
             // The Docker image that should be used for the EL client; leave blank to use the default for the client type
             // Defaults by client:
-            // - geth: parithoshj/geth:master"
+            // - geth: parithoshj/geth:master
+            // - erigon: thorax/erigon:alpha
             // - nethermind: nethermindeth/nethermind:kiln_0.11
             // - besu: hyperledger/besu:22.4.0-RC2-SNAPSHOT
             "elImage": "",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,9 @@
 * Added support for Erigon as an EL client option (`elType: "erigon"`)
     * Default Erigon docker image (`elImage` module option) is set to [thorax/erigon:devel](https://hub.docker.com/layers/erigon/thorax/erigon/devel/images/sha256-8d1c07fb8b88f8bde6ca2a2d42ff0e0cb0206a0009dacbf9b3571721aaa921d7)
 
+### Changes
+* Switched the default `clImage` for Lighthouse client to `sigp/lighthouse:latest` from `sigp/lighthouse:latest-unstable`
+
 # 0.4.17
 ### Changes
 * Upgraded to module-api-lib 0.14.1, switching to the files API for moving files between containers

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,7 @@
 # 0.4.18
 ### Features
 * Added support for Erigon as an EL client option (`elType: "erigon"`)
-    * Default Erigon docker image (`elImage` module option) is set to [thorax/erigon:alpha](https://hub.docker.com/layers/erigon/thorax/erigon/alpha/images/sha256-6f52dfec4e32a6935ae8de1cc655bb3c453bd0513490f2c1b3a88a4b2582081a)
+    * Default Erigon docker image (`elImage` module option) is set to [thorax/erigon:devel](https://hub.docker.com/layers/erigon/thorax/erigon/devel/images/sha256-8d1c07fb8b88f8bde6ca2a2d42ff0e0cb0206a0009dacbf9b3571721aaa921d7)
 
 # 0.4.17
 ### Changes

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,4 +1,7 @@
-# TBD
+# 0.4.18
+### Features
+* Added support for Erigon as an EL client option (`elType: "erigon"`)
+    * Default Erigon docker image (`elImage` module option) is set to [thorax/erigon:alpha](https://hub.docker.com/layers/erigon/thorax/erigon/alpha/images/sha256-6f52dfec4e32a6935ae8de1cc655bb3c453bd0513490f2c1b3a88a4b2582081a)
 
 # 0.4.17
 ### Changes

--- a/kurtosis-module/impl/module_io/default_params.go
+++ b/kurtosis-module/impl/module_io/default_params.go
@@ -15,6 +15,7 @@ var defaultElImages = map[ParticipantELClientType]string{
 	//       If you change these in any way, modify the example JSON config in the README to reflect this!
 	// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 	ParticipantELClientType_Geth:       "parithoshj/geth:master", // From around 2022-03-03
+	ParticipantELClientType_Erigon:		"thorax/erigon:alpha",
 	ParticipantELClientType_Nethermind: "nethermindeth/nethermind:kiln_0.11",
 	ParticipantELClientType_Besu:       "hyperledger/besu:22.4.0-RC2-SNAPSHOT",
 	// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/kurtosis-module/impl/module_io/default_params.go
+++ b/kurtosis-module/impl/module_io/default_params.go
@@ -15,7 +15,7 @@ var defaultElImages = map[ParticipantELClientType]string{
 	//       If you change these in any way, modify the example JSON config in the README to reflect this!
 	// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 	ParticipantELClientType_Geth:       "parithoshj/geth:master", // From around 2022-03-03
-	ParticipantELClientType_Erigon:		"thorax/erigon:alpha",
+	ParticipantELClientType_Erigon:		"thorax/erigon:devel",
 	ParticipantELClientType_Nethermind: "nethermindeth/nethermind:kiln_0.11",
 	ParticipantELClientType_Besu:       "hyperledger/besu:22.4.0-RC2-SNAPSHOT",
 	// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/kurtosis-module/impl/module_io/default_params.go
+++ b/kurtosis-module/impl/module_io/default_params.go
@@ -15,7 +15,7 @@ var defaultElImages = map[ParticipantELClientType]string{
 	//       If you change these in any way, modify the example JSON config in the README to reflect this!
 	// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 	ParticipantELClientType_Geth:       "parithoshj/geth:master", // From around 2022-03-03
-	ParticipantELClientType_Erigon:		"thorax/erigon:devel",
+	ParticipantELClientType_Erigon:     "thorax/erigon:devel",
 	ParticipantELClientType_Nethermind: "nethermindeth/nethermind:kiln_0.11",
 	ParticipantELClientType_Besu:       "hyperledger/besu:22.4.0-RC2-SNAPSHOT",
 	// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -27,7 +27,7 @@ var defaultClImages = map[ParticipantCLClientType]string{
 	// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 	//       If you change these in any way, modify the example JSON config in the README to reflect this!
 	// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-	ParticipantCLClientType_Lighthouse: "sigp/lighthouse:latest-unstable",
+	ParticipantCLClientType_Lighthouse: "sigp/lighthouse:latest",
 	ParticipantCLClientType_Teku:       "consensys/teku:latest",
 	ParticipantCLClientType_Nimbus:     "parithoshj/nimbus:merge-97cefaa",
 	// NOTE: Prysm actually has two images - a Beacon and a validator - so we pass in a comma-separated

--- a/kurtosis-module/impl/module_io/params.go
+++ b/kurtosis-module/impl/module_io/params.go
@@ -32,6 +32,7 @@ const (
 	//               2) update the default_params for the type you modified
 	// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 	ParticipantELClientType_Geth       ParticipantELClientType = "geth"
+	ParticipantELClientType_Erigon     ParticipantELClientType = "erigon"
 	ParticipantELClientType_Nethermind ParticipantELClientType = "nethermind"
 	ParticipantELClientType_Besu       ParticipantELClientType = "besu"
 	// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -42,8 +43,9 @@ const (
 )
 var validParticipantELClientTypes = map[ParticipantELClientType]bool{
 	ParticipantELClientType_Geth:       true,
+	ParticipantELClientType_Erigon:     true,
 	ParticipantELClientType_Nethermind: true,
-	ParticipantELClientType_Besu: true,
+	ParticipantELClientType_Besu: 		true,
 }
 
 // Participant CL client type "enum"

--- a/kurtosis-module/impl/participant_network/el/erigon/erigon_launcher.go
+++ b/kurtosis-module/impl/participant_network/el/erigon/erigon_launcher.go
@@ -158,14 +158,10 @@ func (launcher *ErigonELClientLauncher) getContainerConfigSupplier(
 			////  that users should NOT store private information in these Kurtosis nodes!
 			"--http.api=admin,engine,net,eth",
 			"--ws",
-			"--ws.addr=0.0.0.0",
-			fmt.Sprintf("--ws.port=%v", wsPortNum),
-			"--ws.api=engine,net,eth",
 			"--allow-insecure-unlock",
 			"--nat=extip:" + privateIpAddr,
-			fmt.Sprintf("--authrpc.port=%v", engineRpcPortNum),
-			"--authrpc.addr=0.0.0.0",
-			"--authrpc.vhosts=*",
+			fmt.Sprintf("--engine.port=%v", engineRpcPortNum),
+			"--engine.addr=0.0.0.0",
 			fmt.Sprintf("--authrpc.jwtsecret=%v", jwtSecretJsonFilepathOnClient),
 		}
 		if len(existingElClients) > 0 {

--- a/kurtosis-module/impl/participant_network/el/erigon/erigon_launcher.go
+++ b/kurtosis-module/impl/participant_network/el/erigon/erigon_launcher.go
@@ -27,7 +27,6 @@ const (
 	tcpDiscoveryPortId = "tcpDiscovery"
 	udpDiscoveryPortId = "udpDiscovery"
 	engineRpcPortId    = "engineRpc"
-	engineWsPortId     = "engineWs"
 
 	// NOTE: This can't be 0x00000....000
 	// See: https://github.com/ethereum/go-ethereum/issues/19547
@@ -35,14 +34,11 @@ const (
 
 	genesisDataMountDirpath = "/genesis"
 
-	prefundedKeysMountDirpath = "/prefunded-keys"
-
 	// The dirpath of the execution data directory on the client container.
 	// NOTE: Container user must have permission to write to this directory.
 	executionDataDirpathOnClientContainer = "/home/erigon/execution-data"
 
 	expectedSecondsForErigonInit                            = 10
-	expectedSecondsPerKeyImport                             = 8
 	expectedSecondsAfterNodeStartUntilHttpServerIsAvailable = 20
 	getNodeInfoTimeBetweenRetries                           = 1 * time.Second
 )
@@ -65,7 +61,7 @@ var verbosityLevels = map[module_io.GlobalClientLogLevel]string{
 
 type ErigonELClientLauncher struct {
 	genesisData *el_genesis.ELGenesisData
-	networkId                            string
+	networkId   string
 }
 
 func NewErigonELClientLauncher(genesisData *el_genesis.ELGenesisData, networkId string) *ErigonELClientLauncher {

--- a/kurtosis-module/impl/participant_network/el/erigon/erigon_launcher.go
+++ b/kurtosis-module/impl/participant_network/el/erigon/erigon_launcher.go
@@ -1,0 +1,204 @@
+package erigon
+
+import (
+	"fmt"
+	"github.com/kurtosis-tech/eth2-merge-kurtosis-module/kurtosis-module/impl/module_io"
+	"github.com/kurtosis-tech/eth2-merge-kurtosis-module/kurtosis-module/impl/participant_network/el"
+	"github.com/kurtosis-tech/eth2-merge-kurtosis-module/kurtosis-module/impl/participant_network/el/el_rest_client"
+	"github.com/kurtosis-tech/eth2-merge-kurtosis-module/kurtosis-module/impl/participant_network/el/mining_waiter"
+	"github.com/kurtosis-tech/eth2-merge-kurtosis-module/kurtosis-module/impl/prelaunch_data_generator/el_genesis"
+	"github.com/kurtosis-tech/kurtosis-core-api-lib/api/golang/lib/enclaves"
+	"github.com/kurtosis-tech/kurtosis-core-api-lib/api/golang/lib/services"
+	"github.com/kurtosis-tech/stacktrace"
+	"path"
+	"strings"
+	"time"
+)
+
+const (
+	rpcPortNum       uint16 = 8545
+	wsPortNum        uint16 = 8546
+	discoveryPortNum uint16 = 30303
+	engineRpcPortNum uint16 = 8551
+
+	// Port IDs
+	rpcPortId          = "rpc"
+	wsPortId           = "ws"
+	tcpDiscoveryPortId = "tcpDiscovery"
+	udpDiscoveryPortId = "udpDiscovery"
+	engineRpcPortId    = "engineRpc"
+	engineWsPortId     = "engineWs"
+
+	// NOTE: This can't be 0x00000....000
+	// See: https://github.com/ethereum/go-ethereum/issues/19547
+	miningRewardsAccount = "0x0000000000000000000000000000000000000001"
+
+	genesisDataMountDirpath = "/genesis"
+
+	prefundedKeysMountDirpath = "/prefunded-keys"
+
+	// The dirpath of the execution data directory on the client container.
+	// NOTE: Container user must have permission to write to this directory.
+	executionDataDirpathOnClientContainer = "/home/erigon/execution-data"
+
+	expectedSecondsForErigonInit                            = 10
+	expectedSecondsPerKeyImport                             = 8
+	expectedSecondsAfterNodeStartUntilHttpServerIsAvailable = 20
+	getNodeInfoTimeBetweenRetries                           = 1 * time.Second
+)
+
+var usedPorts = map[string]*services.PortSpec{
+	rpcPortId:          services.NewPortSpec(rpcPortNum, services.PortProtocol_TCP),
+	wsPortId:           services.NewPortSpec(wsPortNum, services.PortProtocol_TCP),
+	tcpDiscoveryPortId: services.NewPortSpec(discoveryPortNum, services.PortProtocol_TCP),
+	udpDiscoveryPortId: services.NewPortSpec(discoveryPortNum, services.PortProtocol_UDP),
+	engineRpcPortId:    services.NewPortSpec(engineRpcPortNum, services.PortProtocol_TCP),
+}
+var entrypointArgs = []string{"sh", "-c"}
+var verbosityLevels = map[module_io.GlobalClientLogLevel]string{
+	module_io.GlobalClientLogLevel_Error: "1",
+	module_io.GlobalClientLogLevel_Warn:  "2",
+	module_io.GlobalClientLogLevel_Info:  "3",
+	module_io.GlobalClientLogLevel_Debug: "4",
+	module_io.GlobalClientLogLevel_Trace: "5",
+}
+
+type ErigonELClientLauncher struct {
+	genesisData *el_genesis.ELGenesisData
+	networkId                            string
+}
+
+func NewErigonELClientLauncher(genesisData *el_genesis.ELGenesisData, networkId string) *ErigonELClientLauncher {
+	return &ErigonELClientLauncher{genesisData: genesisData, networkId: networkId}
+}
+
+func (launcher *ErigonELClientLauncher) Launch(
+	enclaveCtx *enclaves.EnclaveContext,
+	serviceId services.ServiceID,
+	image string,
+	participantLogLevel string,
+	globalLogLevel module_io.GlobalClientLogLevel,
+	// If empty then the node will be launched as a bootnode
+	existingElClients []*el.ELClientContext,
+	extraParams []string,
+) (resultClientCtx *el.ELClientContext, resultErr error) {
+	logLevel, err := module_io.GetClientLogLevelStrOrDefault(participantLogLevel, globalLogLevel, verbosityLevels)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "An error occurred getting the client log level using participant log level '%v' and global log level '%v'", participantLogLevel, globalLogLevel)
+	}
+
+	containerConfigSupplier := launcher.getContainerConfigSupplier(
+		image,
+		existingElClients,
+		logLevel,
+		extraParams,
+	)
+
+	serviceCtx, err := enclaveCtx.AddService(serviceId, containerConfigSupplier)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "An error occurred launching the Erigon EL client with service ID '%v'", serviceId)
+	}
+
+	restClient := el_rest_client.NewELClientRESTClient(
+		serviceCtx.GetPrivateIPAddress(),
+		rpcPortNum,
+	)
+
+	maxNumRetries := expectedSecondsForErigonInit + expectedSecondsAfterNodeStartUntilHttpServerIsAvailable
+	nodeInfo, err := el.WaitForELClientAvailability(restClient, maxNumRetries, getNodeInfoTimeBetweenRetries)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "An error occurred waiting for the EL client to become available")
+	}
+
+	miningWaiter := mining_waiter.NewMiningWaiter(restClient)
+	result := el.NewELClientContext(
+		"erigon",
+		nodeInfo.ENR,
+		nodeInfo.Enode,
+		serviceCtx.GetPrivateIPAddress(),
+		rpcPortNum,
+		wsPortNum,
+		engineRpcPortNum,
+		miningWaiter,
+	)
+
+	return result, nil
+}
+
+// ====================================================================================================
+//                                       Private Helper Methods
+// ====================================================================================================
+func (launcher *ErigonELClientLauncher) getContainerConfigSupplier(
+	image string,
+	// NOTE: If this is nil, the node will be configured as a bootnode
+	existingElClients []*el.ELClientContext,
+	verbosityLevel string,
+	extraParams []string,
+) func(string) (*services.ContainerConfig, error) {
+	result := func(privateIpAddr string) (*services.ContainerConfig, error) {
+		genesisJsonFilepathOnClient := path.Join(genesisDataMountDirpath, launcher.genesisData.GetErigonGenesisJsonRelativeFilepath())
+		jwtSecretJsonFilepathOnClient := path.Join(genesisDataMountDirpath, launcher.genesisData.GetJWTSecretRelativeFilepath())
+
+		initDatadirCmdStr := fmt.Sprintf(
+			"erigon init --datadir=%v %v",
+			executionDataDirpathOnClientContainer,
+			genesisJsonFilepathOnClient,
+		)
+
+		launchNodeCmdArgs := []string{
+			"erigon",
+			"--verbosity=" + verbosityLevel,
+			"--mine",
+			"--miner.etherbase=" + miningRewardsAccount,
+			"--datadir=" + executionDataDirpathOnClientContainer,
+			"--networkid=" + launcher.networkId,
+			"--http",
+			"--http.addr=0.0.0.0",
+			//// WARNING: The admin info endpoint is enabled so that we can easily get ENR/enode, which means
+			////  that users should NOT store private information in these Kurtosis nodes!
+			"--http.api=admin,engine,net,eth",
+			"--ws",
+			"--ws.addr=0.0.0.0",
+			fmt.Sprintf("--ws.port=%v", wsPortNum),
+			"--ws.api=engine,net,eth",
+			"--allow-insecure-unlock",
+			"--nat=extip:" + privateIpAddr,
+			fmt.Sprintf("--authrpc.port=%v", engineRpcPortNum),
+			"--authrpc.addr=0.0.0.0",
+			"--authrpc.vhosts=*",
+			fmt.Sprintf("--authrpc.jwtsecret=%v", jwtSecretJsonFilepathOnClient),
+		}
+		if len(existingElClients) > 0 {
+			bootnodeContext := existingElClients[0]
+			launchNodeCmdArgs = append(
+				launchNodeCmdArgs,
+				"--bootnodes="+bootnodeContext.GetEnode(),
+			)
+		}
+		if len(extraParams) > 0 {
+			launchNodeCmdArgs = append(launchNodeCmdArgs, extraParams...)
+		}
+		launchNodeCmdStr := strings.Join(launchNodeCmdArgs, " ")
+
+		subcommandStrs := []string{
+			initDatadirCmdStr,
+			launchNodeCmdStr,
+		}
+		commandStr := strings.Join(subcommandStrs, " && ")
+
+		containerConfig := services.NewContainerConfigBuilder(
+			image,
+		).WithUsedPorts(
+			usedPorts,
+		).WithEntrypointOverride(
+			entrypointArgs,
+		).WithCmdOverride([]string{
+			commandStr,
+		}).WithFiles(map[services.FilesArtifactID]string{
+			launcher.genesisData.GetFilesArtifactID(): genesisDataMountDirpath,
+		}).Build()
+
+		return containerConfig, nil
+	}
+	return result
+}

--- a/kurtosis-module/impl/participant_network/participant_network.go
+++ b/kurtosis-module/impl/participant_network/participant_network.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kurtosis-tech/eth2-merge-kurtosis-module/kurtosis-module/impl/participant_network/cl/teku"
 	"github.com/kurtosis-tech/eth2-merge-kurtosis-module/kurtosis-module/impl/participant_network/el"
 	"github.com/kurtosis-tech/eth2-merge-kurtosis-module/kurtosis-module/impl/participant_network/el/besu"
+	"github.com/kurtosis-tech/eth2-merge-kurtosis-module/kurtosis-module/impl/participant_network/el/erigon"
 	"github.com/kurtosis-tech/eth2-merge-kurtosis-module/kurtosis-module/impl/participant_network/el/geth"
 	"github.com/kurtosis-tech/eth2-merge-kurtosis-module/kurtosis-module/impl/participant_network/el/nethermind"
 	"github.com/kurtosis-tech/eth2-merge-kurtosis-module/kurtosis-module/impl/prelaunch_data_generator/cl_genesis"
@@ -124,6 +125,10 @@ func LaunchParticipantNetwork(
 			elGenesisData,
 			gethPrefundedKeysArtifactId,
 			genesis_consts.PrefundedAccounts,
+			networkParams.NetworkID,
+		),
+		module_io.ParticipantELClientType_Erigon: erigon.NewErigonELClientLauncher(
+			elGenesisData,
 			networkParams.NetworkID,
 		),
 		module_io.ParticipantELClientType_Nethermind: nethermind.NewNethermindELClientLauncher(

--- a/kurtosis-module/impl/prelaunch_data_generator/el_genesis/el_genesis_data.go
+++ b/kurtosis-module/impl/prelaunch_data_generator/el_genesis/el_genesis_data.go
@@ -10,12 +10,13 @@ type ELGenesisData struct {
 	// Relative filepaths inside the files artifact where various files can be found
 	jwtSecretRelativeFilepath string
 	gethGenesisJsonRelativeFilepath string
+	erigonGenesisJsonRelativeFilepath string
 	nethermindGenesisJsonRelativeFilepath string
 	besuGenesisJsonRelativeFilepath string
 }
 
-func newELGenesisData(filesArtifactId services.FilesArtifactID, jwtSecretRelativeFilepath string, gethGenesisJsonRelativeFilepath string, nethermindGenesisJsonRelativeFilepath string, besuGenesisJsonRelativeFilepath string) *ELGenesisData {
-	return &ELGenesisData{filesArtifactId: filesArtifactId, jwtSecretRelativeFilepath: jwtSecretRelativeFilepath, gethGenesisJsonRelativeFilepath: gethGenesisJsonRelativeFilepath, nethermindGenesisJsonRelativeFilepath: nethermindGenesisJsonRelativeFilepath, besuGenesisJsonRelativeFilepath: besuGenesisJsonRelativeFilepath}
+func newELGenesisData(filesArtifactId services.FilesArtifactID, jwtSecretRelativeFilepath string, gethGenesisJsonRelativeFilepath string, erigonGenesisJsonRelativeFilepath string, nethermindGenesisJsonRelativeFilepath string, besuGenesisJsonRelativeFilepath string) *ELGenesisData {
+	return &ELGenesisData{filesArtifactId: filesArtifactId, jwtSecretRelativeFilepath: jwtSecretRelativeFilepath, gethGenesisJsonRelativeFilepath: gethGenesisJsonRelativeFilepath, erigonGenesisJsonRelativeFilepath: erigonGenesisJsonRelativeFilepath, nethermindGenesisJsonRelativeFilepath: nethermindGenesisJsonRelativeFilepath, besuGenesisJsonRelativeFilepath: besuGenesisJsonRelativeFilepath}
 }
 
 func (data *ELGenesisData) GetFilesArtifactID() services.FilesArtifactID {
@@ -26,6 +27,9 @@ func (data *ELGenesisData) GetJWTSecretRelativeFilepath() string {
 }
 func (data *ELGenesisData) GetGethGenesisJsonRelativeFilepath() string {
 	return data.gethGenesisJsonRelativeFilepath
+}
+func (data *ELGenesisData) GetErigonGenesisJsonRelativeFilepath() string {
+	return data.erigonGenesisJsonRelativeFilepath
 }
 func (data *ELGenesisData) GetNethermindGenesisJsonRelativeFilepath() string {
 	return data.nethermindGenesisJsonRelativeFilepath

--- a/kurtosis-module/impl/prelaunch_data_generator/el_genesis/el_genesis_data_generator.go
+++ b/kurtosis-module/impl/prelaunch_data_generator/el_genesis/el_genesis_data_generator.go
@@ -22,6 +22,7 @@ const (
 	outputDirpathOnGenerator = "/output"
 
 	gethGenesisFilename = "geth.json"
+	erigonGenesisFilename = "erigon.json"
 	nethermindGenesisFilename = "nethermind.json"
 	besuGenesisFilename = "besu.json"
 
@@ -44,6 +45,16 @@ var allGenesisGenerationCmds = map[string]genesisGenerationCmd{
 	gethGenesisFilename: func(genesisConfigFilepathOnGenerator string)[]string{
 		return []string{
 			"python3",
+			"/apps/el-gen/genesis_geth.py",
+			genesisConfigFilepathOnGenerator,
+		}
+	},
+	erigonGenesisFilename: func(genesisConfigFilepathOnGenerator string)[]string{
+		return []string{
+			"python3",
+			// TODO Erigon uses the same genesis as Geth.
+			// 	Change to dedicated script once the genesis generator for Erigon is added upstream.
+			//  https://github.com/skylenet/ethereum-genesis-generator/tree/master/apps/el-gen
 			"/apps/el-gen/genesis_geth.py",
 			genesisConfigFilepathOnGenerator,
 		}
@@ -184,6 +195,7 @@ func GenerateELGenesisData(
 		elGenesisDataArtifactId,
 		path.Join(path.Base(outputDirpathOnGenerator), jwtSecretFilename),
 		genesisFilenameToRelativeFilepathInArtifact[gethGenesisFilename],
+		genesisFilenameToRelativeFilepathInArtifact[erigonGenesisFilename],
 		genesisFilenameToRelativeFilepathInArtifact[nethermindGenesisFilename],
 		genesisFilenameToRelativeFilepathInArtifact[besuGenesisFilename],
 	)


### PR DESCRIPTION
Closes #90 

### Features
* Added support for Erigon as an EL client option (`elType: "erigon"`)
    * Default Erigon docker image (`elImage` module option) is set to [thorax/erigon:devel](https://hub.docker.com/layers/erigon/thorax/erigon/devel/images/sha256-8d1c07fb8b88f8bde6ca2a2d42ff0e0cb0206a0009dacbf9b3571721aaa921d7)

### Changes
* Switched the default `clImage` for Lighthouse client to `sigp/lighthouse:latest` from `sigp/lighthouse:latest-unstable`