### PR TITLE
Removed public urls from ExecuteResponse

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,4 +1,6 @@
 # TBD
+### Breaking Changes
+* `ExecuteResponse` no longer returns public URLs for services in the module
 
 # 0.4.21
 ### Fixes

--- a/kurtosis-module/impl/forkmon/forkmon_launcher.go
+++ b/kurtosis-module/impl/forkmon/forkmon_launcher.go
@@ -1,7 +1,6 @@
 package forkmon
 
 import (
-	"fmt"
 	"github.com/kurtosis-tech/eth2-merge-kurtosis-module/kurtosis-module/impl/participant_network/cl"
 	"github.com/kurtosis-tech/eth2-merge-kurtosis-module/kurtosis-module/impl/service_launch_utils"
 	"github.com/kurtosis-tech/kurtosis-core-api-lib/api/golang/lib/enclaves"
@@ -15,27 +14,28 @@ const (
 	serviceID = "forkmon"
 	imageName = "ralexstokes/ethereum_consensus_monitor:latest"
 
-	httpPortId = "http"
+	httpPortId     = "http"
 	httpPortNumber = uint16(80)
 
 	forkmonConfigFilepathOnModule = "/tmp/forkmon-config.toml"
 
 	forkmonConfigMountDirpathOnService = "/config"
 )
+
 var usedPorts = map[string]*services.PortSpec{
 	httpPortId: services.NewPortSpec(httpPortNumber, services.PortProtocol_TCP),
 }
 
 type clClientInfo struct {
-	IPAddr string
+	IPAddr  string
 	PortNum uint16
 }
 
 type configTemplateData struct {
-	ListenPortNum uint16
-	CLClientInfo []*clClientInfo
-	SecondsPerSlot uint32
-	SlotsPerEpoch uint32
+	ListenPortNum        uint16
+	CLClientInfo         []*clClientInfo
+	SecondsPerSlot       uint32
+	SlotsPerEpoch        uint32
 	GenesisUnixTimestamp uint64
 }
 
@@ -46,7 +46,7 @@ func LaunchForkmon(
 	genesisUnixTimestamp uint64,
 	secondsPerSlot uint32,
 	slotsPerEpoch uint32,
-) (string, error) {
+) error {
 	allClClientInfo := []*clClientInfo{}
 	for _, clClientCtx := range clClientContexts {
 		info := &clClientInfo{
@@ -63,39 +63,29 @@ func LaunchForkmon(
 		GenesisUnixTimestamp: genesisUnixTimestamp,
 	}
 	if err := service_launch_utils.FillTemplateToPath(configTemplate, templateData, forkmonConfigFilepathOnModule); err != nil {
-		return "", stacktrace.Propagate(err, "An error occurred filling the config file template")
+		return stacktrace.Propagate(err, "An error occurred filling the config file template")
 	}
 	configArtifactId, err := enclaveCtx.UploadFiles(forkmonConfigFilepathOnModule)
 	if err != nil {
-		return "", stacktrace.Propagate(err, "An error occurred uploading Forkmon config file at '%v'", forkmonConfigFilepathOnModule)
+		return stacktrace.Propagate(err, "An error occurred uploading Forkmon config file at '%v'", forkmonConfigFilepathOnModule)
 	}
 
 	containerConfigSupplier := getContainerConfigSupplier(configArtifactId)
 	if err != nil {
-		return "", stacktrace.Propagate(err, "An error occurred getting the container config supplier")
+		return stacktrace.Propagate(err, "An error occurred getting the container config supplier")
 	}
 
-	serviceCtx, err := enclaveCtx.AddService(serviceID, containerConfigSupplier)
+	_, err = enclaveCtx.AddService(serviceID, containerConfigSupplier)
 	if err != nil {
-		return "", stacktrace.Propagate(err, "An error occurred launching the forkmon service")
+		return stacktrace.Propagate(err, "An error occurred launching the forkmon service")
 	}
-
-	publicIpAddr := serviceCtx.GetMaybePublicIPAddress()
-	publicHttpPort, found := serviceCtx.GetPublicPorts()[httpPortId]
-	if !found {
-		return "", stacktrace.NewError("Expected the newly-started forkmon service to have a port with ID '%v' but none was found", httpPortId)
-	}
-
-	publicUrl := fmt.Sprintf("http://%v:%v", publicIpAddr, publicHttpPort.GetNumber())
-	return publicUrl, nil
+	return nil
 }
 
 func getContainerConfigSupplier(
 	configArtifactId services.FilesArtifactID,
-) (
-	func (privateIpAddr string) (*services.ContainerConfig, error),
-) {
-	return func (privateIpAddr string) (*services.ContainerConfig, error) {
+) func(privateIpAddr string) (*services.ContainerConfig, error) {
+	return func(privateIpAddr string) (*services.ContainerConfig, error) {
 		configFilepath := path.Join(forkmonConfigMountDirpathOnService, path.Base(forkmonConfigFilepathOnModule))
 		containerConfig := services.NewContainerConfigBuilder(
 			imageName,

--- a/kurtosis-module/impl/module_io/response.go
+++ b/kurtosis-module/impl/module_io/response.go
@@ -2,14 +2,11 @@ package module_io
 
 // The structure that will be returned, JSON-serialized, from calling this module
 type ExecuteResponse struct {
-	ForkmonPublicURL string	`json:"forkmonUrl"`
-	PrometheusPublicURL string `json:"prometheusUrl"`
 	GrafanaInfo *GrafanaInfo `json:"grafana"`
 }
 
 type GrafanaInfo struct {
-	PublicURL string `json:"url"`
-	DashboardURL string `json:"dashboardUrl"`
-	User string `json:"user"`
-	Password string `json:"password"`
+	DashboardPath string `json:"dashboardPath"`
+	User          string `json:"user"`
+	Password      string `json:"password"`
 }


### PR DESCRIPTION
In Kubernetes, services launched in a module will not have a public URL available. This PR removes public URL reporting from the eth2-merge-module