### PR TITLE
Add YAML support for params

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Ethereum 2 Merge Module
-=======================
+# Ethereum 2 Merge Module
+
 This is a [Kurtosis module][module-docs] that will:
 
 1. Generate EL & CL genesis information using [this genesis generator](https://github.com/skylenet/ethereum-genesis-generator)
@@ -13,154 +13,150 @@ This is a [Kurtosis module][module-docs] that will:
 For much more detailed information about how the merge works in Ethereum testnets, see [this document](https://notes.ethereum.org/@ExXcnR0-SJGthjz1dwkA1A/H1MSKgm3F).
 
 ### Quickstart
+
 1. [Install Docker if you haven't done so already][docker-installation]
 1. [Install the Kurtosis CLI, or upgrade it to the latest version if it's already installed][kurtosis-cli-installation]
 1. Ensure your Docker engine is running:
-    ```bash
-    docker image ls
-    ```
+   ```bash
+   docker image ls
+   ```
 1. Create a file in your home directory `eth2-module-params.json` with the following contents:
 
-    ```javascript
-    {
-        "logLevel": "info"
-    }
-    ```
+   ```yaml
+   logLevel: "info"
+   ```
 
 1. Execute the module, passing in the params from the file:
-    ```bash
-    kurtosis module exec --enclave-id eth2 kurtosistech/eth2-merge-kurtosis-module --execute-params "$(cat ~/eth2-module-params.json)"
-    ```
+   ```bash
+   kurtosis module exec --enclave-id eth2 kurtosistech/eth2-merge-kurtosis-module --execute-params "$(cat ~/eth2-module-params.json)"
+   ```
 
 ### Management
+
 Kurtosis will create a new enclave to house the services of the Ethereum network. [This page][using-the-cli] contains documentation for managing the created enclave & viewing detailed information about it.
 
 ### Configuration
+
 To configure the module behaviour, you can modify your `eth2-module-params.json` file. The full JSON schema that can be passed in is as follows with the defaults ([from here](https://github.com/kurtosis-tech/eth2-merge-kurtosis-module/blob/develop/kurtosis-module/impl/module_io/default_params.go) provided (though note that the `//` comments are for explanation purposes and aren't valid JSON so need to be removed):
 
 You can find the latest Kiln compatible docker images here: https://notes.ethereum.org/@launchpad/kiln
-```javascript
-{
-    // Specification of the participants in the network
-    "participants": [
-        {
-            // The type of EL client that should be started
-            // Valid values are "geth", "nethermind", and "besu"
-            "elType": "geth",
 
-            // The Docker image that should be used for the EL client; leave blank to use the default for the client type
-            // Defaults by client:
-            // - geth: parithoshj/geth:master
-            // - erigon: parithoshj/erigon:merge-2da927b
-            // - nethermind: nethermindeth/nethermind:kiln_shadowfork
-            // - besu: hyperledger/besu:develop
-            "elImage": "",
+```yaml
+#  Specification of the participants in the network
+participants:
+  #  The type of EL client that should be started
+  #  Valid values are "geth", "nethermind", and "besu"
+  - elType: "geth"
 
-            // The log level string that this participant's EL client should log at
-            // If this is emptystring then the global `logLevel` parameter's value will be translated into a string appropriate for the client (e.g. if
-            //  global `logLevel` = `info` then Geth would receive `3`, Besu would receive `INFO`, etc.)
-            // If this is not emptystring, then this value will override the global `logLevel` setting to allow for fine-grained control
-            //  over a specific participant's logging
-            "elLogLevel": "",
+    #  The Docker image that should be used for the EL client; leave blank to use the default for the client type
+    #  Defaults by client:
+    #  - geth: parithoshj/geth:master
+    #  - erigon: parithoshj/erigon:merge-2da927b
+    #  - nethermind: nethermindeth/nethermind:kiln_shadowfork
+    #  - besu: hyperledger/besu:develop
+    elImage: ""
 
-            // A list of optional extra params that will be passed to the EL client container for modifying its behaviour
-            "elExtraParams": [],
+    #  The log level string that this participant's EL client should log at
+    #  If this is emptystring then the global `logLevel` parameter's value will be translated into a string appropriate for the client (e.g. if
+    #   global `logLevel` = `info` then Geth would receive `3`, Besu would receive `INFO`, etc.)
+    #  If this is not emptystring, then this value will override the global `logLevel` setting to allow for fine-grained control
+    #   over a specific participant's logging
+    elLogLevel: ""
 
-            // The type of CL client that should be started
-            // Valid values are "nimbus", "lighthouse", "lodestar", "teku", and "prysm"
-            "clType": "lighthouse",
+    #  A list of optional extra params that will be passed to the EL client container for modifying its behaviour
+    elExtraParams: []
 
-            // The Docker image that should be used for the EL client; leave blank to use the default for the client type
-            // Defaults by client (note that Prysm is different in that it requires two images - a Beacon and a validator - separated by a comma):
-            // - lighthouse: sigp/lighthouse:latest
-            // - teku: consensys/teku:latest
-            // - nimbus: parithoshj/nimbus:merge-79452b7
-            // - prysm: gcr.io/prysmaticlabs/prysm/beacon-chain:latest,gcr.io/prysmaticlabs/prysm/validator:latest
-            // - lodestar: chainsafe/lodestar:next
-            "clImage": "",
+    #  The type of CL client that should be started
+    #  Valid values are "nimbus", "lighthouse", "lodestar", "teku", and "prysm"
+    clType: "lighthouse"
 
+    #  The Docker image that should be used for the EL client; leave blank to use the default for the client type
+    #  Defaults by client (note that Prysm is different in that it requires two images - a Beacon and a validator - separated by a comma):
+    #  - lighthouse: sigp/lighthouse:latest
+    #  - teku: consensys/teku:latest
+    #  - nimbus: parithoshj/nimbus:merge-79452b7
+    #  - prysm: gcr.io/prysmaticlabs/prysm/beacon-chain:latest,gcr.io/prysmaticlabs/prysm/validator:latest
+    #  - lodestar: chainsafe/lodestar:next
+    clImage: ""
 
-            // The log level string that this participant's EL client should log at
-            // If this is emptystring then the global `logLevel` parameter's value will be translated into a string appropriate for the client (e.g. if
-            //  global `logLevel` = `info` then Teku would receive `INFO`, Prysm would receive `info`, etc.)
-            // If this is not emptystring, then this value will override the global `logLevel` setting to allow for fine-grained control
-            //  over a specific participant's logging
-            "clLogLevel": ""
+    #  The log level string that this participant's EL client should log at
+    #  If this is emptystring then the global `logLevel` parameter's value will be translated into a string appropriate for the client (e.g. if
+    #   global `logLevel` = `info` then Teku would receive `INFO`, Prysm would receive `info`, etc.)
+    #  If this is not emptystring, then this value will override the global `logLevel` setting to allow for fine-grained control
+    #   over a specific participant's logging
+    clLogLevel: ""
 
-            // A list of optional extra params that will be passed to the CL client Beacon container for modifying its behaviour
-            // If the client combines the Beacon & validator nodes (e.g. Teku, Nimbus), then this list will be passed to the combined Beacon-validator node
-            "beaconExtraParams": [],
+    #  A list of optional extra params that will be passed to the CL client Beacon container for modifying its behaviour
+    #  If the client combines the Beacon & validator nodes (e.g. Teku, Nimbus), then this list will be passed to the combined Beacon-validator node
+    beaconExtraParams: []
 
-            // A list of optional extra params that will be passed to the CL client validator container for modifying its behaviour
-            // If the client combines the Beacon & validator nodes (e.g. Teku, Nimbus), then this list will also be passed to the combined Beacon-validator node
-            "validatorExtraParams": [],
-        }
-    ],
+    #  A list of optional extra params that will be passed to the CL client validator container for modifying its behaviour
+    #  If the client combines the Beacon & validator nodes (e.g. Teku, Nimbus), then this list will also be passed to the combined Beacon-validator node
+    validatorExtraParams: []
 
-    // Configuration parameters for the Eth network
-    "network": {
-        // The network ID of the Eth1 network
-        "networkId": "3151908",
+#  Configuration parameters for the Eth network
+network:
+  #  The network ID of the Eth1 network
+  networkId: "3151908"
 
-        // The address of the staking contract address on the Eth1 chain
-        "depositContractAddress": "0x4242424242424242424242424242424242424242",
+  #  The address of the staking contract address on the Eth1 chain
+  depositContractAddress: "0x4242424242424242424242424242424242424242"
 
-        // Number of seconds per slot on the Beacon chain
-        "secondsPerSlot": 12,
+  #  Number of seconds per slot on the Beacon chain
+  secondsPerSlot: 12
 
-        // Number of slots in an epoch on the Beacon chain
-        "slotsPerEpoch": 32,
+  #  Number of slots in an epoch on the Beacon chain
+  slotsPerEpoch: 32
 
-        // Must come before the merge fork epoch
-        // See https://notes.ethereum.org/@ExXcnR0-SJGthjz1dwkA1A/H1MSKgm3F
-        "altairForkEpoch": 1,
+  #  Must come before the merge fork epoch
+  #  See https://notes.ethereum.org/@ExXcnR0-SJGthjz1dwkA1A/H1MSKgm3F
+  altairForkEpoch: 1
 
-        // Must occur before the total terminal difficulty is hit on the Eth1 chain
-        // See https://notes.ethereum.org/@ExXcnR0-SJGthjz1dwkA1A/H1MSKgm3F
-        "mergeForkEpoch": 2,
+  #  Must occur before the total terminal difficulty is hit on the Eth1 chain
+  #  See https://notes.ethereum.org/@ExXcnR0-SJGthjz1dwkA1A/H1MSKgm3F
+  mergeForkEpoch: 2
 
-        // Once the total difficulty of all mined blocks crosses this threshold, the Eth1 chain will
-        //  merge with the Beacon chain
-        // Must happen after the merge fork epoch on the Beacon chain
-        // See https://notes.ethereum.org/@ExXcnR0-SJGthjz1dwkA1A/H1MSKgm3F
-        "totalTerminalDifficulty": 100000000,
+  #  Once the total difficulty of all mined blocks crosses this threshold, the Eth1 chain will
+  #   merge with the Beacon chain
+  #  Must happen after the merge fork epoch on the Beacon chain
+  #  See https://notes.ethereum.org/@ExXcnR0-SJGthjz1dwkA1A/H1MSKgm3F
+  totalTerminalDifficulty: 100000000
 
-        // The number of validator keys that each CL validator node should get
-        "numValidatorKeysPerNode": 64,
+  #  The number of validator keys that each CL validator node should get
+  numValidatorKeysPerNode: 64
 
-        // This mnemonic will a) be used to create keystores for all the types of validators that we have and b) be used to generate a CL genesis.ssz that has the children
-        //  validator keys already preregistered as validators
-        "preregisteredValidatorKeysMnemonic": "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete"
-    },
+  #  This mnemonic will a) be used to create keystores for all the types of validators that we have and b) be used to generate a CL genesis.ssz that has the children
+  #   validator keys already preregistered as validators
+  preregisteredValidatorKeysMnemonic: "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete"
 
-    // If set to false, we won't wait for the EL clients to mine at least 1 block before proceeding with adding the CL clients
-    // This is purely for debug purposes; waiting for blockNumber > 0 is required for the CL network to behave as
-    //  expected, but that wait can be several minutes. Skipping the wait can be a good way to shorten the debug loop on a
-    //  CL client that's failing to start.
-    "waitForMining": true,
+#  If set to false, we won't wait for the EL clients to mine at least 1 block before proceeding with adding the CL clients
+#  This is purely for debug purposes; waiting for blockNumber > 0 is required for the CL network to behave as
+#   expected, but that wait can be several minutes. Skipping the wait can be a good way to shorten the debug loop on a
+#   CL client that's failing to start.
+waitForMining: true
 
-    // If set, the module will block until a finalized epoch has occurred.
-    // If `waitForVerifications` is set to true, this extra wait will be skipped.
-    "waitForFinalization": false,
+#  If set, the module will block until a finalized epoch has occurred.
+#  If `waitForVerifications` is set to true, this extra wait will be skipped.
+waitForFinalization: false
 
-    // If set to true, the module will block until all verifications have passed
-    "waitForVerifications": false,
+#  If set to true, the module will block until all verifications have passed
+waitForVerifications: false
 
-    // If set, this will be the maximum number of epochs to wait for the TTD to be reached.
-    // Verifications will be marked as failed if the TTD takes longer.
-    "verificationsTTDEpochLimit": 5,
+#  If set, this will be the maximum number of epochs to wait for the TTD to be reached.
+#  Verifications will be marked as failed if the TTD takes longer.
+verificationsTTDEpochLimit: 5
 
-    // If set, after the merge, this will be the maximum number of epochs wait for the verifications to succeed. 
-    "verificationsEpochLimit": 5,
+#  If set, after the merge, this will be the maximum number of epochs wait for the verifications to succeed.
+verificationsEpochLimit: 5
 
-    // The global log level that all clients should log at
-    // Valid values are "error", "warn", "info", "debug", and "trace"
-    // This value will be overridden by participant-specific values
-    "logLevel": "info"
-}
+#  The global log level that all clients should log at
+#  Valid values are "error", "warn", "info", "debug", and "trace"
+#  This value will be overridden by participant-specific values
+logLevel: "info"
 ```
 
 ### Development
+
 To develop on this module, install Go and:
 
 1. Make your code changes
@@ -168,6 +164,7 @@ To develop on this module, install Go and:
 1. Slot the image that's outputted into your `kurtosis module exec` command (e.g. `kurtosis module exec kurtosistech/eth2-merge-kurtosis-module:my-test-branch`)
 
 <!-- Only links below here -->
+
 [docker-installation]: https://docs.docker.com/get-docker/
 [kurtosis-cli-installation]: https://docs.kurtosistech.com/installation.html
 [module-docs]: https://docs.kurtosistech.com/modules.html

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,7 @@
 # TBD
 
+* Add support for YAML in input serialized params
+
 # 0.5.3
 ### Changes
 * Upgraded to module-api-lib 0.16.0, core 1.54.1 and engine 1.26.1 for latest Kurtosis compatibility

--- a/kurtosis-module/impl/module_configurator.go
+++ b/kurtosis-module/impl/module_configurator.go
@@ -1,7 +1,7 @@
 package impl
 
 import (
-	"encoding/json"
+	"gopkg.in/yaml.v3"
 	"github.com/kurtosis-tech/kurtosis-module-api-lib/golang/lib/kurtosis_modules"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
@@ -11,10 +11,10 @@ const(
 	defaultLogLevel = "info"
 )
 
-// Parameters that the module accepts when loaded, serializeda as JSON
+// Parameters that the module accepts when loaded, serialized as JSON
 type LoadModuleParams struct {
 	// Indicates the log level for this Kurtosis module implementation
-	LogLevel string `json:"logLevel"`
+	LogLevel string `yaml:"logLevel"`
 }
 
 type Eth2KurtosisModuleConfigurator struct{}
@@ -26,7 +26,7 @@ func NewEth2KurtosisModuleConfigurator() *Eth2KurtosisModuleConfigurator {
 func (t Eth2KurtosisModuleConfigurator) ParseParamsAndCreateExecutableModule(serializedCustomParamsStr string) (kurtosis_modules.ExecutableKurtosisModule, error) {
 	serializedCustomParamsBytes := []byte(serializedCustomParamsStr)
 	var args LoadModuleParams
-	if err := json.Unmarshal(serializedCustomParamsBytes, &args); err != nil {
+	if err := yaml.Unmarshal(serializedCustomParamsBytes, &args); err != nil {
 		return nil, stacktrace.Propagate(err, "An error occurred deserializing the Kurtosis module serialized custom params with value '%v", serializedCustomParamsStr)
 	}
 

--- a/kurtosis-module/impl/module_io/default_params.go
+++ b/kurtosis-module/impl/module_io/default_params.go
@@ -40,7 +40,7 @@ var defaultClImages = map[ParticipantCLClientType]string{
 }
 
 // To see the exact JSON keys needed to override these values, see the ExecuteParams object and look for the
-//  `json:"XXXXXXX"` metadata on the ExecuteParams properties
+//  `yaml:"XXXXXXX"` metadata on the ExecuteParams properties
 func GetDefaultExecuteParams() *ExecuteParams {
 	// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 	//       If you change these in any way, modify the example JSON config in the README to reflect this!

--- a/kurtosis-module/impl/module_io/params.go
+++ b/kurtosis-module/impl/module_io/params.go
@@ -77,108 +77,108 @@ var validParticipantCLClientTypes = map[ParticipantCLClientType]bool{
 
 type ExecuteParams struct {
 	// Parameters controlling the types of clients that compose the network
-	Participants []*ParticipantParams `json:"participants"`
+	Participants []*ParticipantParams `yaml:"participants"`
 
 	// Parameters controlling the settings of the network itself
-	Network *NetworkParams	`json:"network"`
+	Network *NetworkParams	`yaml:"network"`
 
 	// If set to false, we won't wait for the EL clients to mine at least 1 block before proceeding with adding the CL clients
 	// This is purely for debug purposes; waiting for blockNumber > 0 is required for the CL network to behave as
 	//  expected, but that wait can be several minutes. Skipping the wait can be a good way to shorten the debug loop on a
 	//  CL client that's failing to start.
-	WaitForMining bool			`json:"waitForMining"`
+	WaitForMining bool			`yaml:"waitForMining"`
 
 	// If set, the module will block until a finalized epoch has occurred.
 	// If `waitForVerifications` is set to true, this extra wait will be skipped.
-	WaitForFinalization bool	`json:"waitForFinalization"`
+	WaitForFinalization bool	`yaml:"waitForFinalization"`
 
 	// If set to true, the module will block until all verifications have passed
-	WaitForVerifications bool `json:"waitForVerifications"`
+	WaitForVerifications bool `yaml:"waitForVerifications"`
 
 	// If set, this will be the maximum number of epochs to wait for the TTD to be reached.
     // Verifications will be marked as failed if the TTD takes longer.
-	VerificationsTTDEpochLimit uint64 `json:"verificationsTTDEpochLimit"`
+	VerificationsTTDEpochLimit uint64 `yaml:"verificationsTTDEpochLimit"`
 
 	// If set, after the merge, this will be the maximum number of epochs wait for the verifications to succeed. 
-	VerificationsEpochLimit uint64 `json:"verificationsEpochLimit"`
+	VerificationsEpochLimit uint64 `yaml:"verificationsEpochLimit"`
 
 	// The log level that the started clients should log at
-	ClientLogLevel GlobalClientLogLevel `json:"logLevel"`
+	ClientLogLevel GlobalClientLogLevel `yaml:"logLevel"`
 }
 
 type ParticipantParams struct {
 	// The type of EL client that should be started
-	ELClientType ParticipantELClientType `json:"elType"`
+	ELClientType ParticipantELClientType `yaml:"elType"`
 
 	// The Docker image that should be used for the EL client; leave blank to use the default
-	ELClientImage string `json:"elImage"`
+	ELClientImage string `yaml:"elImage"`
 
 	// The log level string that this participant's EL client should log at
 	// If this is emptystring then the global `logLevel` parameter's value will be translated into a string appropriate for the client (e.g. if
 	//  global `logLevel` = `info` then Geth would receive `3`, Besu would receive `INFO`, etc.)
 	// If this is not emptystring, then this value will override the global `logLevel` setting to allow for fine-grained control
 	//  over a specific participant's logging
-	ELClientLogLevel string `json:"elLogLevel"`
+	ELClientLogLevel string `yaml:"elLogLevel"`
 
 	// Optional extra parameters that will be passed to the EL client
-	ELExtraParams []string				 `json:"elExtraParams"`
+	ELExtraParams []string				 `yaml:"elExtraParams"`
 
 	// The type of CL client that should be started
-	CLClientType ParticipantCLClientType `json:"clType"`
+	CLClientType ParticipantCLClientType `yaml:"clType"`
 
 	// The Docker image that should be used for the EL client; leave blank to use the default
 	// NOTE: Prysm is different in that it requires two images - a Beacon and a validator
 	//  For Prysm and Prysm only, this field should contain a comma-separated string of "beacon_image,validator_image"
-	CLClientImage string `json:"clImage"`
+	CLClientImage string `yaml:"clImage"`
 
 	// The log level string that this participant's CL client should log at
 	// If this is emptystring then the global `logLevel` parameter's value will be translated into a string appropriate for the client (e.g. if
 	//  global `logLevel` = `info` then Nimbus would receive `INFO`, Prysm would receive `info`, etc.)
 	// If this is not emptystring, then this value will override the global `logLevel` setting to allow for fine-grained control
 	//  over a specific participant's logging
-	CLClientLogLevel string `json:"clLogLevel"`
+	CLClientLogLevel string `yaml:"clLogLevel"`
 
 	// Extra parameters that will be passed to the Beacon container (if a separate one exists), or to the combined node if
 	// the Beacon and validator are combined
-	BeaconExtraParams []string `json:"beaconExtraParams"`
+	BeaconExtraParams []string `yaml:"beaconExtraParams"`
 
 	// Extra parameters that will be passed to the validator container (if a separate one exists), or to the combined node if
 	// the Beacon and validator are combined
-	ValidatorExtraParams []string `json:"validatorExtraParams"`
+	ValidatorExtraParams []string `yaml:"validatorExtraParams"`
 }
 
 // Parameters controlling particulars of the Eth1 & Eth2 networks
 type NetworkParams struct {
 	// The network ID of the Eth1 network
-	NetworkID string	`json:"networkId"`
+	NetworkID string	`yaml:"networkId"`
 
 	// The address of the staking contract address on the Eth1 chain
-	DepositContractAddress string	`json:"depositContractAddress"`
+	DepositContractAddress string	`yaml:"depositContractAddress"`
 
 	// Number of seconds per slot on the Beacon chain
-	SecondsPerSlot uint32	`json:"secondsPerSlot"`
+	SecondsPerSlot uint32	`yaml:"secondsPerSlot"`
 
 	// Number of slots in an epoch on the Beacon chain
-	SlotsPerEpoch uint32	`json:"slotsPerEpoch"`
+	SlotsPerEpoch uint32	`yaml:"slotsPerEpoch"`
 
 	// Must come before the merge fork epoch
 	// See https://notes.ethereum.org/@ExXcnR0-SJGthjz1dwkA1A/H1MSKgm3F
-	AltairForkEpoch uint64	`json:"altairForkEpoch"`
+	AltairForkEpoch uint64	`yaml:"altairForkEpoch"`
 
 	// Must occur before the total terminal difficulty is hit on the Eth1 chain
 	// See https://notes.ethereum.org/@ExXcnR0-SJGthjz1dwkA1A/H1MSKgm3F
-	MergeForkEpoch uint64	`json:"mergeForkEpoch"`
+	MergeForkEpoch uint64	`yaml:"mergeForkEpoch"`
 
 	// Once the total difficulty of all mined blocks crosses this threshold, the Eth1 chain will
 	//  merge with the Beacon chain
 	// Must happen after the merge fork epoch on the Beacon chain
 	// See https://notes.ethereum.org/@ExXcnR0-SJGthjz1dwkA1A/H1MSKgm3F
-	TotalTerminalDifficulty uint64	`json:"totalTerminalDifficulty"`
+	TotalTerminalDifficulty uint64	`yaml:"totalTerminalDifficulty"`
 
 	// The number of validator keys that each CL validator node should get
-	NumValidatorKeysPerNode uint32	`json:"numValidatorKeysPerNode"`
+	NumValidatorKeysPerNode uint32	`yaml:"numValidatorKeysPerNode"`
 
 	// This menmonic will a) be used to create keystores for all the types of validators that we have and b) be used to generate a CL genesis.ssz that has the children
 	//  validator keys already preregistered as validators
-	PreregisteredValidatorKeysMnemonic string	`json:"preregisteredValidatorKeysMnemonic"`
+	PreregisteredValidatorKeysMnemonic string	`yaml:"preregisteredValidatorKeysMnemonic"`
 }

--- a/kurtosis-module/impl/module_io/params_deserializer.go
+++ b/kurtosis-module/impl/module_io/params_deserializer.go
@@ -1,7 +1,7 @@
 package module_io
 
 import (
-	"encoding/json"
+	"gopkg.in/yaml.v3"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
 	"strings"
@@ -18,7 +18,7 @@ const (
 
 func DeserializeAndValidateParams(paramsStr string) (*ExecuteParams, error) {
 	paramsObj := GetDefaultExecuteParams()
-	if err := json.Unmarshal([]byte(paramsStr), paramsObj); err != nil {
+	if err := yaml.Unmarshal([]byte(paramsStr), paramsObj); err != nil {
 		return nil, stacktrace.Propagate(err, "An error occurred deserializing the serialized params")
 	}
 


### PR DESCRIPTION
JSON is a subset of YAML, so switching to a YAML parser allows consumers to choose between specifying the params as JSON or YAML.

A nice side-effect is that the README example with comments is usable as is.

I've tested a local build with both .yaml and .json and both work file.
- .yaml test: README example as is
- .json test: see below

```json
{
  "participants": [
    {
      "elType": "geth",
      "elImage": "",
      "elLogLevel": "",
      "elExtraParams": [],
      "clType": "lighthouse",
      "clImage": "",
      "clLogLevel": "",
      "beaconExtraParams": [],
      "validatorExtraParams": []
    }
  ],

  "network": {
    "networkId": "3151908",
    "depositContractAddress": "0x4242424242424242424242424242424242424242",
    "secondsPerSlot": 12,
    "slotsPerEpoch": 32,
    "altairForkEpoch": 1,
    "mergeForkEpoch": 2,
    "totalTerminalDifficulty": 100000000,
    "numValidatorKeysPerNode": 64,
    "preregisteredValidatorKeysMnemonic": "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete"
  },
  "waitForMining": true,
  "waitForFinalization": false,
  "waitForVerifications": false,
  "verificationsTTDEpochLimit": 5,
  "verificationsEpochLimit": 5,
  "logLevel": "infoLLLOLLOL-JSON"
}
```
