### PR TITLE
Geth: open up vhost/cors configs by adding relevant flags. explicitly set empty bootnode for first node.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,6 @@
 # TBD
 
+* Geth: open up vhost/cors configs by adding relevant flags. explicitly set empty bootnode for first node.
 * Add support for YAML in input serialized params
 
 # 0.5.3


### PR DESCRIPTION
I think it's fine opening up vhosts/cors configurations for geth for testing purposes.

This came to my radar because I've seen the following logs on a Teku node:

``` 
2022-07-01 04:47:59.473 WARN  - Eth1 service down or still syncing for 30s, retrying
2022-07-01 04:48:29.426 WARN  - Endpoint 191.163.48.6:8545 [1] is INVALID | Still syncing
``` 

It wasn't clear in that log line, but this is due to geth having the vhosts limited to "localhost" by default.

Addiitionally I've also set the `--bootnodes` flag to be empty on the first node to avoid peering up with any statically defined bootnodes in the geth codebase. 