### PR TITLE
Replace executionLayerOnly flag with launchAdditionalService flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,14 +137,14 @@ network:
   #   validator keys already preregistered as validators
   preregisteredValidatorKeysMnemonic: "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete"
 
-# If set to true:
-#  - only the EL nodes & the transaction spammer will be started
-#  - everything CL nodes & after will be skipped (including Forkmon)
+# True by defaults such that in addition to the Ethereum network:
+#  - A transaction spammer is launched to fake transactions sent to the network
+#  - Forkmon will be launched after CL genesis has happened
+#  - A prometheus will be started, coupled with grafana
+# If set to false:
+#  - only Ethereum network (EL and CL nodes) will be launched. Nothing else (no transaction spammer)
 #  - params for the CL nodes will be ignored (e.g. CL node image, CL node extra params)
-#  - the response will be missing URLs for things started after the EL ndoes
-#  - EL-node-only params like loglevel and `waitForMining` will still be used
-# NOTE: You will probably want to adjust the `totalTerminalDifficulty` much higher to ensure the EL nodes don't go through the Merge (as they won't have CL nodes)
-executionLayerOnly: false
+launchAdditionalServices: true
 
 #  If set, the module will block until a finalized epoch has occurred.
 #  If `waitForVerifications` is set to true, this extra wait will be skipped.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,9 +1,15 @@
 # TBD
 
+### Breaking Changes
+* The config flag `executionLayerOnly` has been removed
+* A new config flag `launchAdditionalService` has been added. True by default, it controls the launch of services
+additional service like Forkmon, Prometheus and Grafana, as well as the transaction spammer. Is set to false, only the
+Ethereum network (EL _and_ CL nodes) are launched
+
 ### Changes
 * Updated flags
 * Switched to `merged` genesis state instead of `phase0`
-* Removed support for mining 
+* Removed support for mining
 
 ### Features
 - Added more detailed instructions on how to submit PRs to this repo

--- a/kurtosis-module/impl/module.go
+++ b/kurtosis-module/impl/module.go
@@ -81,9 +81,6 @@ func (e Eth2KurtosisModule) Execute(enclaveCtx *enclaves.EnclaveContext, seriali
 	logrus.Infof("Adding %v participants logging at level '%v'...", numParticipants, paramsObj.ClientLogLevel)
 	participants, clGenesisUnixTimestamp, err := participant_network.LaunchParticipantNetwork(
 		ctx,
-		// TODO this is a temporary hack to enable starting an EL-only network; we're working on fixing this in a productized
-		//  way in Kurtosis itself
-		paramsObj.ExecutionLayerOnly,
 		enclaveCtx,
 		networkParams,
 		paramsObj.Participants,
@@ -105,7 +102,7 @@ func (e Eth2KurtosisModule) Execute(enclaveCtx *enclaves.EnclaveContext, seriali
 	logrus.Infof("Successfully added %v participants", numParticipants)
 
 	// TODO This is a temporary hack to add only EL nodes until the product supports easily decomposing this module
-	if paramsObj.ExecutionLayerOnly {
+	if !paramsObj.LaunchAdditionalServices {
 		return "{}", nil
 	}
 

--- a/kurtosis-module/impl/module_io/default_params.go
+++ b/kurtosis-module/impl/module_io/default_params.go
@@ -65,11 +65,11 @@ func GetDefaultExecuteParams() *ExecuteParams {
 			NumValidatorKeysPerNode:            64,
 			PreregisteredValidatorKeysMnemonic: "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete",
 		},
-		ExecutionLayerOnly:      false,
-		WaitForFinalization:     false,
-		WaitForVerifications:    false,
-		VerificationsEpochLimit: 5,
-		ClientLogLevel:          GlobalClientLogLevel_Info,
+		LaunchAdditionalServices: true,
+		WaitForFinalization:      false,
+		WaitForVerifications:     false,
+		VerificationsEpochLimit:  5,
+		ClientLogLevel:           GlobalClientLogLevel_Info,
 	}
 	// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 	//       If you change these in any way, modify the example JSON config in the README to reflect this!

--- a/kurtosis-module/impl/module_io/params.go
+++ b/kurtosis-module/impl/module_io/params.go
@@ -88,15 +88,17 @@ type ExecuteParams struct {
 	// Parameters controlling the settings of the network itself
 	Network *NetworkParams `yaml:"network"`
 
-	// If set to true:
-	//  - only the EL nodes & the transaction spammer will be started
-	//  - everything CL nodes & after will be skipped (including Forkmon)
+	// True by defaults such that in addition to the Ethereum network:
+	//  - A transaction spammer is launched to fake transactions sent to the network
+	//  - Forkmon will be launched after CL genesis has happened
+	//  - a prometheus will be started, coupled with grafana
+	// If set to false:
+	//  - only Ethereum network (EL and CL nodes) will be launched. Nothing else (no transaction spammer)
 	//  - params for the CL nodes will be ignored (e.g. CL node image, CL node extra params)
-	//  - the response will be missing URLs for things started after the EL ndoes
 	// This is a hack - it's not very elegant - but this is a commonly-requested feature
 	// The longterm solution is making the module trivial to decompose so we don't need flags like this; we're working
 	//  on this at the Kurtosis product level
-	ExecutionLayerOnly bool `yaml:"executionLayerOnly"`
+	LaunchAdditionalServices bool `yaml:"launchAdditionalServices"`
 
 	// If set, the module will block until a finalized epoch has occurred.
 	// If `waitForVerifications` is set to true, this extra wait will be skipped.

--- a/kurtosis-module/impl/participant_network/participant_network.go
+++ b/kurtosis-module/impl/participant_network/participant_network.go
@@ -52,8 +52,6 @@ var clClientContextForBootClClients *cl.CLClientContext = nil
 
 func LaunchParticipantNetwork(
 	ctx context.Context,
-	// TODO this is a hack to allow for starting just the EL nodes! This will be fixed by Kurtosis product work
-	shouldStartJustELNodes bool,
 	enclaveCtx *enclaves.EnclaveContext,
 	networkParams *module_io.NetworkParams,
 	allParticipantSpecs []*module_io.ParticipantParams,
@@ -170,23 +168,6 @@ func LaunchParticipantNetwork(
 		logrus.Infof("Added EL client %v of type '%v'", idx, elClientType)
 	}
 	logrus.Infof("Successfully added %v EL clients", numParticipants)
-	// TODO This is a temporary hack to enable starting an EL-node-only network!
-	//  Will be fixed by Kurtosis product work to make the module easily decomposable
-	if shouldStartJustELNodes {
-		resultParticipants := []*Participant{}
-		for idx, participantSpec := range allParticipantSpecs {
-			elClientCtx := allElClientContexts[idx]
-			participant := NewParticipant(
-				participantSpec.ELClientType,
-				participantSpec.CLClientType,
-				elClientCtx,
-				nil,
-				nil,
-			)
-			resultParticipants = append(resultParticipants, participant)
-		}
-		return resultParticipants, 0, nil
-	}
 
 	// We create the CL genesis data after the EL network is ready so that the CL genesis timestamp will be close
 	//  to the time the CL nodes are started


### PR DESCRIPTION
CL and EL nodes are always run in the post-merge world.
We added a flag to control the launch of extra services like Forkmon, Prometheus and Grafana, as well as the transaction spammer